### PR TITLE
Use a size_t format string for value from strlen()

### DIFF
--- a/src/vmod_cookie.c
+++ b/src/vmod_cookie.c
@@ -76,7 +76,7 @@ vmod_parse(VRT_CTX, struct vmod_priv *priv, VCL_STRING cookieheader) {
 		return;
 	}
 
-	VSLb(ctx->vsl, SLT_Debug, "cookie: cookie string is %lu bytes.", strlen(cookieheader));
+	VSLb(ctx->vsl, SLT_Debug, "cookie: cookie string is %zu bytes.", strlen(cookieheader));
 
 	if (strlen(cookieheader) >= MAX_COOKIE_STRING) {
 		VSLb(ctx->vsl, SLT_VCL_Log, "cookie: cookie string overflowed, abort");
@@ -110,7 +110,7 @@ vmod_parse(VRT_CTX, struct vmod_priv *priv, VCL_STRING cookieheader) {
 		value = sepindex + 1;
 		*sepindex = '\0';
 
-		VSLb(ctx->vsl, SLT_Debug, "value length is %lu.", strlen(value));
+		VSLb(ctx->vsl, SLT_Debug, "value length is %zu.", strlen(value));
 		vmod_set(ctx, priv, token, value);
 		i++;
 	}


### PR DESCRIPTION
Two format strings in src/vmod_cookie.c used "%lu" for the size_t returned from
strlen().  This works on 64bit, but not on a 32bit platform. This commit changes those to "%zu" instead.

Originally reported as [Debian bug #817169](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=817169)
