### PR TITLE
Provide absolute path for vcc files for extra_dist

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -66,7 +66,9 @@ $(top_srcdir)/src/tests/*/*.vtc:
 
 check: $(VMOD_TESTS)
 
-EXTRA_DIST = foreign *vcc $(VMOD_TESTS) \
+EXTRA_DIST = foreign \
+	$(top_srcdir)/src/*vcc \
+	$(VMOD_TESTS) \
 	vtree.h
 
 CLEANFILES = $(builddir)/vcc*if.c $(builddir)/vcc*if.h \


### PR DESCRIPTION
make distcheck first makes a distribution and then tries to do a VPATH build.
A complete path to where the *vcc files lie is necessary to install the package during the VPATH build.

Fixes #1 