### PR TITLE
document /tmp directory needs to be mounted in executable mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,10 @@ Source code is built with autotools::
 The resulting loadable modules (``libvmod_foo*.so`` files) will be installed to
 the Varnish module directory. (default `/usr/lib/varnish/vmods/`)
 
+If /tmp directory is mounted with ``noexec``, a safe TMPDIR needs to be passed:
+
+    mkdir -p tmp && TMPDIR=$(pwd)/tmp make check
+
 
 Usage
 -----


### PR DESCRIPTION
added documentation about varnishtest only running in a /tmp directory mounted with exec option

closes #19 