### PR TITLE
Mark Varnish Plus related checks for xkey

### DIFF
--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -486,9 +486,11 @@ purge(VRT_CTX, VCL_STRING key, VCL_INT do_soft)
 	int i;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
+#ifdef VARNISH_PLUS
+        /* These are only used in the Varnish Plus mode of rearm */
 	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->req->wrk, WORKER_MAGIC);
-
+#endif
 	if (!key || !*key)
 		return (0);
 


### PR DESCRIPTION
Only check the ctx->req and ctx->req->wrk if we're running Varnish Plus.

They're only needed for the Varnish Plus interface of Rearm.