### PR TITLE
Fugly rules to omit vmod-tcp when unsupported

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,16 @@ AC_CHECK_MEMBER(struct objcore.exp,
 	[], [#include <cache/cache.h>])
 CFLAGS="$save_CFLAGS"
 
+AC_CHECK_TYPE(struct tcp_info,
+	[AC_DEFINE([HAVE_TCP_INFO], [1],
+		[Define if struct tcp_info is present])],
+	[], [[
+		#include <sys/types.h>
+		#include <sys/socket.h>
+		#include <netinet/tcp.h>
+		#include <netinet/in.h>
+	]])
+
 AC_CONFIG_FILES([
 	Makefile
 	src/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -47,10 +47,10 @@ VARNISH_VMODS([
 
 save_CFLAGS="$CFLAGS"
 CFLAGS="$VARNISHAPI_CFLAGS"
-AC_CHECK_MEMBERS(struct objcore.exp,
-  [AC_DEFINE([HAVE_OBJCORE_EXP], [1],
-    [Define if exp is present in the objcore struct])],
-  [], [#include <cache/cache.h>])
+AC_CHECK_MEMBER(struct objcore.exp,
+	[AC_DEFINE([HAVE_OBJCORE_EXP], [1],
+		[Define if exp is present in the objcore struct])],
+	[], [#include <cache/cache.h>])
 CFLAGS="$save_CFLAGS"
 
 AC_CONFIG_FILES([


### PR DESCRIPTION
Works on my machine, how about on @quintonparker's?
