### PR TITLE
Fix libtoolize not installing ltmain.sh on RHEL =< 6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@ AC_PREREQ(2.59)
 AC_COPYRIGHT([Copyright (c) 2016 Varnish Software Group])
 AC_INIT([varnish-modules], [0.9.1])
 AC_CONFIG_MACRO_DIR([m4])
+AC_CONFIG_AUX_DIR([.])
 m4_ifndef([VARNISH_VMOD_INCLUDES], AC_MSG_ERROR([Need varnish.m4 -- see README.rst]))
 AM_CONFIG_HEADER(config.h)
 


### PR DESCRIPTION
Hello !

Here's a fix to be able to compile varnish-modules under RHEL 6 ( at least ).

Build output can be found here : https://travis-ci.org/gboddin/edge-repo/builds/155194300 

Also, just in case, both varnish and varnish-modules are packaged there : http://repo.siwhine.net

Discussion about ltmain.sh missing on libtoolize : https://github.com/akheron/jansson/issues/182 