### PR TITLE
Modify vmod-xkey purge() to accept multiple space-delimited keys

### DIFF
--- a/src/tests/xkey/test07.vtc
+++ b/src/tests/xkey/test07.vtc
@@ -1,0 +1,52 @@
+varnishtest "Test xkey vmod multiple objects purging multiple keys"
+
+server s1 {
+	rxreq
+	txresp -hdr "xkey: asdf"
+	rxreq
+	txresp -hdr "xkey: fdsa"
+} -start
+
+varnish v1 -vcl+backend {
+	import xkey from "${vmod_builddir}/.libs/libvmod_xkey.so";
+
+	sub vcl_recv {
+		if (req.http.xkey-purge) {
+			if (xkey.purge(req.http.xkey-purge) != 0) {
+				return (synth(200, "Purged"));
+			} else {
+				return (synth(404, "No key"));
+			}
+		}
+	}
+
+	sub vcl_backend_response {
+		set beresp.ttl = 60s;
+		set beresp.grace = 0s;
+		set beresp.keep = 0s;
+	}
+
+	sub vcl_synth {
+		set resp.http.reason = resp.reason;
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+	txreq -url /2
+	rxresp
+} -run
+
+varnish v1 -expect n_object == 2
+
+client c1 {
+	txreq -hdr "xkey-purge: asdf fdsa"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.reason == "Purged"
+} -run
+
+delay 1
+
+varnish v1 -expect n_object == 0

--- a/src/tests/xkey/test08.vtc
+++ b/src/tests/xkey/test08.vtc
@@ -1,12 +1,8 @@
-varnishtest "Test xkey vmod multiple objects purging multiple keys"
+varnishtest "Test xkey vmod purge non-existant key"
 
 server s1 {
 	rxreq
-	txresp -hdr "xkey: 1000  2000	3000"
-	rxreq
-	txresp -hdr "xkey: 4000	   5000 6000"
-	rxreq
-	txresp -hdr "xkey:  7000  8000  9000"
+	txresp -hdr "xkey: asdf fdsa"
 } -start
 
 varnish v1 -vcl+backend {
@@ -34,23 +30,19 @@ varnish v1 -vcl+backend {
 } -start
 
 client c1 {
-	txreq -url /one
-	rxresp
-	txreq -url /two
-	rxresp
-	txreq -url /three
+	txreq
 	rxresp
 } -run
 
-varnish v1 -expect n_object == 3
+varnish v1 -expect n_object == 1
 
 client c1 {
-	txreq -hdr "xkey-purge:	1000  5000	9000"
+	txreq -hdr "xkey-purge: xyz"
 	rxresp
-	expect resp.status == 200
-	expect resp.http.reason == "Purged"
+	expect resp.status == 404
+	expect resp.http.reason == "No key"
 } -run
 
 delay 1
 
-varnish v1 -expect n_object == 0
+varnish v1 -expect n_object == 1

--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -568,7 +568,6 @@ purge(VRT_CTX, VCL_STRING key, VCL_INT do_soft)
 		AZ(pthread_mutex_unlock(&mtx));
 		sp = ep;
 	}
-
 	return (i);
 }
 

--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -500,7 +500,8 @@ purge(VRT_CTX, VCL_STRING key, VCL_INT do_soft)
 	unsigned char digest[DIGEST_LEN];
 	struct xkey_hashhead *hashhead;
 	struct xkey_oc *oc;
-	int i;
+	int i = 0;
+	const char *ep, *sp;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
@@ -508,57 +509,68 @@ purge(VRT_CTX, VCL_STRING key, VCL_INT do_soft)
 
 	if (!key || !*key)
 		return (0);
+	sp = key;
+	while (*sp != '\0') {
+		while (*sp == ' ')
+			sp++;
+		ep = sp;
+		while (*ep != '\0' && *ep != ' ')
+			ep++;
+		if (sp == ep)
+			break;
 
-	SHA256_Init(&sha_ctx);
-	SHA256_Update(&sha_ctx, key, strlen(key));
-	SHA256_Final(digest, &sha_ctx);
+                SHA256_Init(&sha_ctx);
+                SHA256_Update(&sha_ctx, sp, ep - sp);
+                SHA256_Final(digest, &sha_ctx);
 
-	AZ(pthread_mutex_lock(&mtx));
-	hashhead = xkey_hashtree_lookup(digest, sizeof(digest));
-	if (hashhead == NULL) {
-		AZ(pthread_mutex_unlock(&mtx));
-		return (0);
-	}
-	i = 0;
-	VTAILQ_FOREACH(oc, &hashhead->ocs, list_hashhead) {
-		CHECK_OBJ_NOTNULL(oc->objcore, OBJCORE_MAGIC);
-		if (oc->objcore->flags & OC_F_BUSY)
-			continue;
+                AZ(pthread_mutex_lock(&mtx));
+                hashhead = xkey_hashtree_lookup(digest, sizeof(digest));
+                if (hashhead == NULL) {
+                        AZ(pthread_mutex_unlock(&mtx));
+                        continue;
+                }
+                VTAILQ_FOREACH(oc, &hashhead->ocs, list_hashhead) {
+                        CHECK_OBJ_NOTNULL(oc->objcore, OBJCORE_MAGIC);
+                        if (oc->objcore->flags & OC_F_BUSY)
+                                continue;
 #if defined HAVE_OBJCORE_EXP
-		if (do_soft && oc->objcore->exp.ttl <=
-		    (ctx->now - oc->objcore->exp.t_origin))
-			continue;
+			if (do_soft && oc->objcore->exp.ttl <=
+			    (ctx->now - oc->objcore->exp.t_origin))
+				continue;
 #else
-		if (do_soft &&
-		    oc->objcore->ttl <= (ctx->now - oc->objcore->t_origin))
-			continue;
+			if (do_soft &&
+			    oc->objcore->ttl <= (ctx->now - oc->objcore->t_origin))
+				continue;
 #endif
 #ifdef VARNISH_PLUS
-		if (do_soft)
-			EXP_Rearm(ctx->req->wrk, oc->objcore, ctx->now, 0,
-			    oc->objcore->exp.grace, oc->objcore->exp.keep);
-		else
-			EXP_Rearm(ctx->req->wrk, oc->objcore,
-			    oc->objcore->exp.t_origin, 0, 0, 0);
+			if (do_soft)
+				EXP_Rearm(ctx->req->wrk, oc->objcore, ctx->now, 0,
+				    oc->objcore->exp.grace, oc->objcore->exp.keep);
+			else
+				EXP_Rearm(ctx->req->wrk, oc->objcore,
+				    oc->objcore->exp.t_origin, 0, 0, 0);
 #elif defined HAVE_OBJCORE_EXP
-		if (do_soft)
-			EXP_Rearm(oc->objcore, ctx->now, 0,
-			    oc->objcore->exp.grace, oc->objcore->exp.keep);
-		else
-			EXP_Rearm(oc->objcore, oc->objcore->exp.t_origin,
-			    0, 0, 0);
+			if (do_soft)
+				EXP_Rearm(oc->objcore, ctx->now, 0,
+				    oc->objcore->exp.grace, oc->objcore->exp.keep);
+			else
+				EXP_Rearm(oc->objcore, oc->objcore->exp.t_origin,
+				    0, 0, 0);
 #else
-		if (do_soft)
-			EXP_Rearm(oc->objcore, ctx->now, 0,
-			    oc->objcore->grace, oc->objcore->keep);
-		else
-			EXP_Rearm(oc->objcore, oc->objcore->t_origin,
-			    0, 0, 0);
+			if (do_soft)
+				EXP_Rearm(oc->objcore, ctx->now, 0,
+				    oc->objcore->grace, oc->objcore->keep);
+			else
+				EXP_Rearm(oc->objcore, oc->objcore->t_origin,
+				    0, 0, 0);
 #endif
 
-		i++;
+			i++;
+		}
+		AZ(pthread_mutex_unlock(&mtx));
+		sp = ep;
 	}
-	AZ(pthread_mutex_unlock(&mtx));
+
 	return (i);
 }
 

--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -414,10 +414,10 @@ xkey_cb_insert(struct worker *wrk, struct objcore *objcore)
 		AN(sp);
 		sp++;
 		while (*sp != '\0') {
-			while (isspace(*sp))
+			while (isblank(*sp))
 				sp++;
 			ep = sp;
-			while (*ep != '\0' && !isspace(*ep))
+			while (*ep != '\0' && !isblank(*ep))
 				ep++;
 			if (sp == ep)
 				break;
@@ -511,10 +511,10 @@ purge(VRT_CTX, VCL_STRING key, VCL_INT do_soft)
 		return (0);
 	sp = key;
 	while (*sp != '\0') {
-		while (isspace(*sp))
+		while (isblank(*sp))
 			sp++;
 		ep = sp;
-		while (*ep != '\0' && !isspace(*ep))
+		while (*ep != '\0' && !isblank(*ep))
 			ep++;
 		if (sp == ep)
 			break;

--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -419,7 +419,7 @@ xkey_cb_insert(struct worker *wrk, struct objcore *objcore)
 			ep = sp;
 			while (*ep != '\0' && !isblank(*ep))
 				ep++;
-			if (sp == ep)
+			if (*sp == '\0')
 				break;
 			SHA256_Init(&sha_ctx);
 			SHA256_Update(&sha_ctx, sp, ep - sp);
@@ -516,7 +516,7 @@ purge(VRT_CTX, VCL_STRING key, VCL_INT do_soft)
 		ep = sp;
 		while (*ep != '\0' && !isblank(*ep))
 			ep++;
-		if (sp == ep)
+		if (*sp == '\0')
 			break;
 
                 SHA256_Init(&sha_ctx);


### PR DESCRIPTION
The vmod-xkey module allows multiple space-delimited keys to be set per object, e.g.

xkey: abcd efgh ijkl mnop

However the purge() and softpurge() methods currently only support a single input key:

xkey.purge('abcd');

This pull request simply replicates the string-processing logic from xkey_cb_insert() and applies it in purge() so that the purge() and softpurge() methods support a space-delimited list of keys, e.g:

xkey.purge("abcd efgh ijkl mnop");
xkey.softpurge("abcd efgh ijkl mnop");

This allows multiple keys to be purged / soft-purged in a single request.

While the changeset seems large, it's mainly due to indentation (and unit test), there were no changes to the core logic in the purge() function.