### PR TITLE
Fix cookie parsing

### DIFF
--- a/src/tests/cookie/10-parser.vtc
+++ b/src/tests/cookie/10-parser.vtc
@@ -1,6 +1,6 @@
 varnishtest "Test cookie parser"
 
-server s1 -repeat 5 {
+server s1 -repeat 6 {
        rxreq
        txresp
 } -start
@@ -44,4 +44,11 @@ client c5 {
 	txreq -hdr "Cookie: cookie1=foobarbaz"
 	rxresp
 	expect resp.http.X-foo == "cookie1=foobarbaz;"
+} -run
+
+# Don't overflow the buffer with an edge case
+client c6 {
+	txreq -hdr "Cookie: csrftoken=0e0c3616e41a6bd561b72b7f5fc1128a;=" -hdr "X-Not-Cookie: sessionid=a707505310ddf259bb290d3ca63fc561"
+	rxresp
+	expect resp.http.X-foo == "csrftoken=0e0c3616e41a6bd561b72b7f5fc1128a;"
 } -run

--- a/src/vmod_cookie.c
+++ b/src/vmod_cookie.c
@@ -118,13 +118,14 @@ vmod_parse(VRT_CTX, struct vmod_priv *priv, VCL_STRING cookieheader) {
 			break;
 		}
 		value = strndup(p, pdiff(p, sep));
-		if (sep != '\0')
-			p = sep + 1;
 
 		vmod_set(ctx, priv, name, value);
 		free(name);
 		free(value);
 		i++;
+		if (*sep == '\0')
+			break;
+		p = sep + 1;
 	}
 	VSLb(ctx->vsl, SLT_VCL_Log, "cookie: parsed %i cookies.", i);
 }


### PR DESCRIPTION
sep != '\0' is always true (see if (sep == NULL) above).

If *sep == '\0', the parser will skip over the NUL terminator
and keep parsing other headers and the request body looking
for cookies.