### PR TITLE
cleanup include order

### DIFF
--- a/src/vmod_cookie.c
+++ b/src/vmod_cookie.c
@@ -28,14 +28,15 @@
  */
 
 #define _GNU_SOURCE
+#include "config.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
 
+#include "cache/cache.h"
 #include "vrt.h"
 #include "vqueue.h"
-#include "cache/cache.h"
 
 #include "vcc_cookie_if.h"
 

--- a/src/vmod_header.c
+++ b/src/vmod_header.c
@@ -26,15 +26,15 @@
  * SUCH DAMAGE.
  */
 
+#include "config.h"
 #include <stdlib.h>
 #include <pthread.h>
 
 #include "vcl.h"
-#include "vrt.h"
 #include "cache/cache.h"
+#include "vrt.h"
 
 #include "vcc_header_if.h"
-#include "config.h"
 
 /*
  * This mutex is used to avoid having two threads that initializes the same

--- a/src/vmod_saintmode.c
+++ b/src/vmod_saintmode.c
@@ -26,13 +26,14 @@
  * SUCH DAMAGE.
  */
 
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>
 
 #include "vcl.h"
-#include "vrt.h"
 #include "cache/cache.h"
+#include "vrt.h"
 #include "cache/cache_director.h"
 #include "cache/cache_backend.h"
 

--- a/src/vmod_softpurge.c
+++ b/src/vmod_softpurge.c
@@ -25,11 +25,11 @@
  * SUCH DAMAGE.
  */
 
+#include "config.h"
+#include "cache/cache.h"
 #include "vrt.h"
 #include "vcl.h"
-#include "cache/cache.h"
 #include "hash/hash_slinger.h"
-#include "config.h"
 
 #include "vcc_softpurge_if.h"
 

--- a/src/vmod_tcp.c
+++ b/src/vmod_tcp.c
@@ -25,15 +25,14 @@
  * SUCH DAMAGE.
  */
 
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "vrt.h"
 #include "cache/cache.h"
+#include "vrt.h"
 
 #include "vcc_tcp_if.h"
-
-#include "config.h"
 
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/src/vmod_var.c
+++ b/src/vmod_var.c
@@ -25,13 +25,14 @@
  * SUCH DAMAGE.
  */
 
+#include "config.h"
 #include <stdlib.h>
 #include <ctype.h>
 #include <sys/socket.h>
 
+#include "cache/cache.h"
 #include "vrt.h"
 #include "vsa.h"
-#include "cache/cache.h"
 
 #include "vcc_var_if.h"
 

--- a/src/vmod_vsthrottle.c
+++ b/src/vmod_vsthrottle.c
@@ -26,6 +26,7 @@
  * SUCH DAMAGE.
  */
 
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -35,6 +36,7 @@
 #include <errno.h>
 
 #include "vcl.h"
+#include "vdef.h"
 #include "vrt.h"
 #include "vas.h"
 #include "vtim.h"

--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -26,15 +26,15 @@
  * SUCH DAMAGE.
  */
 
+#include "config.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>
 
 #include "vcl.h"
-#include "vrt.h"
 #include "cache/cache.h"
+#include "vrt.h"
 #include "vsha256.h"
-#include "config.h"
 
 #include "vtree.h"
 


### PR DESCRIPTION
- config.h first
- cache.h or (additional) vdef.h before vrt.h

this is required for master since 81bc4cef2a5e651a9e34ae5400672a88663db7ef

Survives make check with 5.0 release and 4.1 branch