### PR TITLE
fix build on centos6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ(2.63)
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_SRCDIR(src/vmod_cookie.vcc)
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 
 AM_INIT_AUTOMAKE([1.11 foreign])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
build on centos6 requires autoconf-2.65, automake-1.13, and this change
in configure.ac