### PR TITLE
Clearify documentation on vmod-cookie and Set-Cookie

### DIFF
--- a/docs/vmod_cookie.rst
+++ b/docs/vmod_cookie.rst
@@ -34,8 +34,8 @@ but a set comma-separated list of cookies. A filter() method removes a comma-
 separated list of cookies.
 
 A convenience function for formatting the Set-Cookie Expires date field
-is also included. If there are multiple Set-Cookie headers vmod-header
-should be used.
+is also included. To actually manipulate the Set-Cookie response headers,
+vmod-header should be used instead though.
 
 The state loaded with cookie.parse() has a lifetime of the current request
 or backend request context. To pass variables to the backend request, store


### PR DESCRIPTION
As discussed with @gquintard in issue #66 this VMOD shouldn't be used to manipulate
the Set-Cookie response headers. This small change tries to make the documentation clearer.