### PR TITLE
New vmod_uuid

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ VARNISH_VMODS([
 	var
 	vsthrottle
 	xkey
+	uuid
 ])
 
 save_CFLAGS="$CFLAGS"
@@ -61,6 +62,13 @@ AC_CHECK_TYPE(struct tcp_info,
 		#include <sys/socket.h>
 		#include <netinet/tcp.h>
 		#include <netinet/in.h>
+	]])
+
+AC_CHECK_TYPE(const uuid_t,
+	[AC_DEFINE([HAVE_UUID_UUID_H], [1],
+		[Define if const uuid_t is present])],
+	[AC_MSG_ERROR([uuid.h is missing, install uuid and uuid-dev])], [[
+		#include <uuid/uuid.h>
 	]])
 
 # Test suite

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,7 +31,8 @@ vmod_LTLIBRARIES = \
 	libvmod_tcp.la \
 	libvmod_var.la \
 	libvmod_vsthrottle.la \
-	libvmod_xkey.la
+	libvmod_xkey.la \
+	libvmod_uuid.la
 
 dist_man_MANS = \
 	vmod_bodyaccess.3 \
@@ -42,7 +43,8 @@ dist_man_MANS = \
 	vmod_tcp.3 \
 	vmod_var.3 \
 	vmod_vsthrottle.3 \
-	vmod_xkey.3
+	vmod_xkey.3 \
+	vmod_uuid.3
 
 generated_docs = $(dist_man_MANS:.3=.rst)
 
@@ -55,6 +57,8 @@ libvmod_softpurge_la_SOURCES = vmod_softpurge.c foreign/hash/hash_slinger.h
 libvmod_tcp_la_SOURCES = vmod_tcp.c
 libvmod_var_la_SOURCES = vmod_var.c
 libvmod_xkey_la_SOURCES = vmod_xkey.c
+libvmod_uuid_la_SOURCES = vmod_uuid.c
+libvmod_uuid_la_LIBADD = -luuid
 
 nodist_libvmod_bodyaccess_la_SOURCES = vcc_bodyaccess_if.c vcc_bodyaccess_if.h
 nodist_libvmod_cookie_la_SOURCES = vcc_cookie_if.c vcc_cookie_if.h
@@ -65,6 +69,7 @@ nodist_libvmod_softpurge_la_SOURCES = vcc_softpurge_if.c vcc_softpurge_if.h
 nodist_libvmod_tcp_la_SOURCES = vcc_tcp_if.c vcc_tcp_if.h
 nodist_libvmod_var_la_SOURCES = vcc_var_if.c vcc_var_if.h
 nodist_libvmod_xkey_la_SOURCES = vcc_xkey_if.c vcc_xkey_if.h
+nodist_libvmod_uuid_la_SOURCES = vcc_uuid_if.c vcc_uuid_if.h
 
 @BUILD_VMOD_BODYACCESS@
 @BUILD_VMOD_COOKIE@
@@ -75,6 +80,7 @@ nodist_libvmod_xkey_la_SOURCES = vcc_xkey_if.c vcc_xkey_if.h
 @BUILD_VMOD_VAR@
 @BUILD_VMOD_VSTHROTTLE@
 @BUILD_VMOD_XKEY@
+@BUILD_VMOD_UUID@
 
 rst-docs: $(generated_docs)
 	cp $(generated_docs) $(top_srcdir)/docs/
@@ -108,4 +114,5 @@ EXTRA_DIST = \
 	vmod_tcp.vcc \
 	vmod_var.vcc \
 	vmod_vsthrottle.vcc \
-	vmod_xkey.vcc
+	vmod_xkey.vcc \
+	vmod_uuid.vcc

--- a/src/tests/uuid/01-get_rand_uuid.vtc
+++ b/src/tests/uuid/01-get_rand_uuid.vtc
@@ -1,0 +1,25 @@
+varnishtest "Test uuid vmod"
+
+
+server s1 {
+       rxreq
+       txresp
+} -start
+
+varnish v1 -vcl+backend {
+        import uuid from "${vmod_builddir}/.libs/libvmod_uuid.so";
+
+	sub vcl_recv {
+	}
+	sub vcl_deliver {
+            set resp.http.X-uuid = uuid.get_rand_uuid();
+	}
+} -start
+
+client c1 {
+	txreq -url "/"
+	rxresp
+        expect resp.http.X-uuid ~ "[-a-f0-9]{36,36}"
+}
+
+client c1 -run

--- a/src/vmod_uuid.c
+++ b/src/vmod_uuid.c
@@ -1,0 +1,54 @@
+/*-
+ * Copyright (c) 2015 Varnish Software
+ * All rights reserved.
+ *
+ * Author: Stephan Doliov <stephandoliov@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <uuid/uuid.h>
+#include <string.h>
+
+#include "vcl.h"
+#include "vrt.h"
+#include "cache/cache.h"
+
+#include "vcc_uuid_if.h"
+
+VCL_STRING
+vmod_get_rand_uuid(VRT_CTX)
+{
+
+    char *output;
+    uuid_t uuid;
+    uuid_generate_random(uuid);
+    char uuid_hex[37];
+    uuid_unparse_lower(uuid,uuid_hex);
+    output = WS_Copy(ctx->ws,uuid_hex,37);
+    return (output);
+
+}

--- a/src/vmod_uuid.vcc
+++ b/src/vmod_uuid.vcc
@@ -1,0 +1,108 @@
+$Module uuid 3 Varnish UUID Module
+DESCRIPTION
+===========
+
+Allows on the fly generation of UUIDs (random)
+
+Useful for doing some on the fly random cookie value generation
+to enable cookie delivery and caching
+
+Typically used with both vmod_cookie, vmod_header and vmod_std
+
+.. vcl-start
+
+Cookie manipulation (end-to-end) example::
+
+    vcl 4.0;
+
+    import std;
+    import header;
+    import cookie;
+    import uuid;
+
+    backend default { .host = "192.0.2.11"; .port = "8080"; }
+
+    sub vcl_recv {
+        /* force all requests to carry one random guid cookie on req but write
+           this into an http.X-... header for retrieval in delivery phase
+           assumes "YOUR_COOKIE_NAME" is a random guid
+        */
+
+        if (req.http.cookie) {
+            cookie.parse(req.http.cookie);
+            if (cookie.isset("YOUR_COOKIE_NAME")) {
+                set.req.http.X-YOUR_COOKIE_NAME = cookie.get("YOUR_COOKIE_NAME");
+            }
+        }
+        else {
+            /* if you don't have cookies inbound, you can pseudo assign one here
+               so the varnish response, if cacheable just serve the cache and overwrite the
+               set-cookie header in vcl deliver
+            */
+            set req.http.X-YOUR_COOKIE_NAME = uuid.get_rand_uuid();
+        }
+
+        ## now on response you can retrieve cookie values in vcl_deliver
+        ## and make this response cacheable by unsetting the inbound cookie headers
+        unset req.http.cookie;
+    }
+
+    sub vcl_backend_fetch {
+        ## if your site handles CORS, make sure that a CORS OPTIONS
+        ## request gets to backend with proper method!
+        if (bereq.http.X-is-options) {
+            set bereq.method = "OPTIONS";
+        }
+        return (fetch);
+    }
+
+    sub vcl_backend_response {
+        var.set("cacheable","false");
+        ## when you get to responses that might be cacheable
+        ## e.g., fresh, cookieless reqs...
+        if (YOUR_CACHEABLE_CRITERIA) {
+            var.set("cacheable","true");
+            unset beresp.http.set-cookie;
+            set beresp.http.is-cacheable = 1;
+        }
+        else {
+            set beresp.uncacheable = true;
+        }
+        return (deliver);
+    }
+
+    sub vcl_deliver {
+        ## code illustrated here assumes only one valuable inbound request cookie existed
+        ## but this logic can apply to as many inbound request cookies came
+        ## that are just played back with fresher expirations
+        var.set("domain","; Domain=YOURDOMAIN");
+        var.set("path","; PATH=YOURPATH");
+
+        if (resp.http.is-cacheable) {
+            unset beresp.http.set-cookie;
+            if (req.http.X-YOUR_COOKIE_NAME "") {
+                var.set("expires","; Expires=" + cookie.format_rfc1123(now,1h));
+                var.set("max-age","; Max-Age=" + 60*60);
+                header.append(resp.http.Set-Cookie,"YOUR_COOKIE_NAME=" + req.http.X-YOUR_COOKIE_NAME + var.get("domain") + var.get("expires") + var.get("max-age") + var.get("path"));
+            }
+            ## set as many of these inbound request cookies that were rewritten into http.X-headers
+            ## as your heart desires
+        }
+
+        ## clean up X-headers that came with cached response that were just to help
+        ## varnish keep state
+        unset resp.http.is-cacheable;
+    }
+
+.. vcl-end
+
+$Function STRING get_rand_uuid()
+
+Description
+        Fetch a random uuid 
+Example
+        ::
+
+                sub vcl_deliver {
+                        set resp.http.X-uuid-cookie-val = uuid.get_rand_uuid();
+                }


### PR DESCRIPTION
This vmod allows for generating a random uuid from within vcl. It's useful for handling uuid format session identifying cookies that either need to be intercepted and rewritten to an req.http.X-header or for cookieless inbound requests where we'd like to serve the response body from cache but make sure an appropriate uuid format session cookie is sent to the client and not leaking hte cookie that was cached.