### PR TITLE
Add a DURATION param to is_denied() to block everything during that period.

### DIFF
--- a/src/tests/vsthrottle/test03.vtc
+++ b/src/tests/vsthrottle/test03.vtc
@@ -1,0 +1,101 @@
+varnishtest "Test the block parameter"
+
+varnish v1 -vcl {
+	import vsthrottle from "${vmod_builddir}/.libs/libvmod_vsthrottle.so";
+        backend b { .host = "${bad_ip}"; }
+
+        sub vcl_recv {
+                return(synth(200));
+        }
+
+	sub vcl_synth {
+                set resp.http.block-1 = vsthrottle.is_denied("quux", 2, 1s, 2s);
+                return(deliver);
+	}
+} -start
+
+client c1 {
+	txreq
+        rxresp
+        expect resp.http.block-1 == "false"
+
+	txreq
+	rxresp
+        expect resp.http.block-1 == "false"
+
+	txreq
+	rxresp
+        expect resp.http.block-1 == "true"
+
+        delay 1.1
+	txreq
+	rxresp
+        expect resp.http.block-1 == "true"
+
+        delay 1.1
+	txreq
+	rxresp
+        expect resp.http.block-1 == "false"
+} -run
+
+# If block <= 0s, then is_denied() ignores it. So this is just the
+# same test as in test01.vtc, except that block is set with such a
+# value.
+varnish v1 -vcl {
+	import vsthrottle from "${vmod_builddir}/.libs/libvmod_vsthrottle.so";
+        backend b { .host = "${bad_ip}"; }
+
+        sub vcl_recv {
+                return(synth(200));
+        }
+
+	sub vcl_synth {
+		set resp.http.foo-count0
+                    = vsthrottle.remaining("foo", 1, 1s, -1s);
+		if (!vsthrottle.is_denied("foo", 1, 1s, -1s)) {
+			set resp.http.f1 = "OK";
+		}
+		set resp.http.foo-count1
+                    = vsthrottle.remaining("foo", 1, 1s, -1s);
+
+		if (!vsthrottle.is_denied("foo", 1, 1s, -1s)) {
+			set resp.http.f2 = "OK";
+		}
+		set resp.http.foo-count2
+                    = vsthrottle.remaining("foo", 1, 1s, -1s);
+
+		set resp.http.bar-count0
+                    = vsthrottle.remaining("bar", 1, 1s, 0s);
+		if (!vsthrottle.is_denied("bar", 1, 1s, 0s)) {
+			set resp.http.f3 = "OK";
+		}
+		set resp.http.bar-count1
+                    = vsthrottle.remaining("bar", 1, 1s, 0s);
+
+		set resp.http.f4-count0
+                    = vsthrottle.remaining(req.http.not-found, 1, 1s, -2s);
+		if (vsthrottle.is_denied(req.http.not-found, 10, 100s, -2s)) {
+			set resp.http.f4 = "NULL";
+		}
+		set resp.http.f4-count1
+                    = vsthrottle.remaining(req.http.not-found, 1, 1s, -2s);
+
+                return(deliver);
+	}
+}
+
+client c1 {
+	txreq
+	rxresp
+	expect resp.http.f1 == "OK"
+	expect resp.http.foo-count0 == "1"
+	expect resp.http.foo-count1 == "0"
+	expect resp.http.f2 == <undef>
+	expect resp.http.foo-count2 == "0"
+	expect resp.http.f3 == "OK"
+	expect resp.http.bar-count0 == "1"
+	expect resp.http.bar-count1 == "0"
+	expect resp.http.f4 == "NULL"
+	expect resp.http.f4-count0 == "-1"
+	expect resp.http.f4-count1 == "-1"
+} -run

--- a/src/tests/vsthrottle/test03.vtc
+++ b/src/tests/vsthrottle/test03.vtc
@@ -57,18 +57,18 @@ varnish v1 -vcl {
 
 	sub vcl_synth {
 		set resp.http.foo-count0
-                    = vsthrottle.remaining("foo", 1, 1s, -1s);
-		if (!vsthrottle.is_denied("foo", 1, 1s, -1s)) {
+                    = vsthrottle.remaining("foo", 1, 1s, 0s);
+		if (!vsthrottle.is_denied("foo", 1, 1s, 0s)) {
 			set resp.http.f1 = "OK";
 		}
 		set resp.http.foo-count1
-                    = vsthrottle.remaining("foo", 1, 1s, -1s);
+                    = vsthrottle.remaining("foo", 1, 1s, 0s);
 
-		if (!vsthrottle.is_denied("foo", 1, 1s, -1s)) {
+		if (!vsthrottle.is_denied("foo", 1, 1s, 0s)) {
 			set resp.http.f2 = "OK";
 		}
 		set resp.http.foo-count2
-                    = vsthrottle.remaining("foo", 1, 1s, -1s);
+                    = vsthrottle.remaining("foo", 1, 1s, 0s);
 
 		set resp.http.bar-count0
                     = vsthrottle.remaining("bar", 1, 1s, 0s);
@@ -79,12 +79,12 @@ varnish v1 -vcl {
                     = vsthrottle.remaining("bar", 1, 1s, 0s);
 
 		set resp.http.f4-count0
-                    = vsthrottle.remaining(req.http.not-found, 1, 1s, -2s);
-		if (vsthrottle.is_denied(req.http.not-found, 10, 100s, -2s)) {
+                    = vsthrottle.remaining(req.http.not-found, 1, 1s, 0s);
+		if (vsthrottle.is_denied(req.http.not-found, 10, 100s, 0s)) {
 			set resp.http.f4 = "NULL";
 		}
 		set resp.http.f4-count1
-                    = vsthrottle.remaining(req.http.not-found, 1, 1s, -2s);
+                    = vsthrottle.remaining(req.http.not-found, 1, 1s, 0s);
 
                 return(deliver);
 	}

--- a/src/tests/vsthrottle/test03.vtc
+++ b/src/tests/vsthrottle/test03.vtc
@@ -9,7 +9,8 @@ varnish v1 -vcl {
         }
 
 	sub vcl_synth {
-                set resp.http.block-1 = vsthrottle.is_denied("quux", 2, 1s, 2s);
+                set resp.http.block = vsthrottle.is_denied("quux", 2, 1s, 2s);
+                set resp.http.blocked = vsthrottle.blocked("quux", 2, 1s, 2s);
                 return(deliver);
 	}
 } -start
@@ -17,25 +18,30 @@ varnish v1 -vcl {
 client c1 {
 	txreq
         rxresp
-        expect resp.http.block-1 == "false"
+        expect resp.http.block == "false"
+        expect resp.http.blocked ~ "^0[.]0+$"
 
 	txreq
 	rxresp
-        expect resp.http.block-1 == "false"
+        expect resp.http.block == "false"
+        expect resp.http.blocked ~ "^0[.]0+$"
 
 	txreq
 	rxresp
-        expect resp.http.block-1 == "true"
-
-        delay 1.1
-	txreq
-	rxresp
-        expect resp.http.block-1 == "true"
+        expect resp.http.block == "true"
+        expect resp.http.blocked ~ "^[12][.][0-9]+$"
 
         delay 1.1
 	txreq
 	rxresp
-        expect resp.http.block-1 == "false"
+        expect resp.http.block == "true"
+        expect resp.http.blocked ~ "^0[.][0-9]+$"
+
+        delay 1.1
+	txreq
+	rxresp
+        expect resp.http.block == "false"
+        expect resp.http.blocked ~ "^0[.]0+$"
 } -run
 
 # If block <= 0s, then is_denied() ignores it. So this is just the

--- a/src/vmod_vsthrottle.c
+++ b/src/vmod_vsthrottle.c
@@ -182,6 +182,7 @@ vmod_is_denied(VRT_CTX, VCL_STRING key, VCL_INT limit, VCL_DURATION period,
 	if (b->block > 0. && now < b->block) {
 		AZ(b->tokens);
 		ret = 1;
+		b->last_used = now;
 	}
 	else {
 		calc_tokens(b, now);

--- a/src/vmod_vsthrottle.c
+++ b/src/vmod_vsthrottle.c
@@ -272,9 +272,9 @@ vmod_blocked(VRT_CTX, VCL_STRING key, VCL_INT limit, VCL_DURATION period,
 	now = VTIM_mono();
 	b = get_bucket(digest, limit, period, now);
 	ret = b->block - now;
+	AZ(pthread_mutex_unlock(&v->mtx));
 	if (ret <= 0.)
 		ret = 0.;
-	AZ(pthread_mutex_unlock(&v->mtx));
 	return (ret);
 }
 

--- a/src/vmod_vsthrottle.c
+++ b/src/vmod_vsthrottle.c
@@ -271,12 +271,10 @@ vmod_blocked(VRT_CTX, VCL_STRING key, VCL_INT limit, VCL_DURATION period,
 	AZ(pthread_mutex_lock(&v->mtx));
 	now = VTIM_mono();
 	b = get_bucket(digest, limit, period, now);
-	if (b->block == 0.)
+	ret = b->block - now;
+	if (ret <= 0.)
 		ret = 0.;
-	else
-		ret = b->block - now;
 	AZ(pthread_mutex_unlock(&v->mtx));
-	assert(ret >= 0.);
 	return (ret);
 }
 

--- a/src/vmod_vsthrottle.vcc
+++ b/src/vmod_vsthrottle.vcc
@@ -117,3 +117,29 @@ Example
      sub vcl_deliver {
 	set resp.http.X-RateLimit-Remaining = vsthrottle.remaining(client.identity, 15, 10s);
      }
+
+$Function DURATION blocked(STRING key, INT limit, DURATION period,
+                           DURATION block)
+
+Arguments:
+  - key: A unique identifier to define what is being throttled
+  - limit: How many requests in the specified period
+  - period: The time period
+  - block: duration to block
+
+Description
+
+  If the token bucket identified by the four parameters has been
+  blocked by use of the 'block' parameter in 'is_denied()', then
+  return the time remaining in the block. If it is not blocked,
+  return 0s. This can be used to inform clients how long they
+  will be locked out.
+
+
+Example
+  ::
+
+     sub vcl_deliver {
+	set resp.http.Retry-After
+		= vsthrottle.blocked(client.identity, 15, 10s, 30s);
+     }

--- a/src/vmod_vsthrottle.vcc
+++ b/src/vmod_vsthrottle.vcc
@@ -13,6 +13,12 @@ The request rate is specified as the number of requests permitted over
 a period. To keep things simple, this is passed as two separate
 parameters, 'limit' and 'period'.
 
+If an optional duration 'block' is specified, then access is denied
+altogether for that period of time after the rate limit is
+reached. This is a way to entirely turn away a particularly
+troublesome source of traffic for a while, rather than let them back
+in as soon as the rate slips back under the threshold.
+
 This VMOD implements a `token bucket algorithm`_. State associated
 with the token bucket for each key is stored in-memory using BSD's
 red-black tree implementation.
@@ -34,8 +40,9 @@ Example::
     sub vcl_recv {
         # Varnish will set client.identity for you based on client IP.
 
-        if (vsthrottle.is_denied(client.identity, 15, 10s)) {
-            # Client has exceeded 15 reqs per 10s
+        if (vsthrottle.is_denied(client.identity, 15, 10s, 30s)) {
+            # Client has exceeded 15 reqs per 10s.
+            # When this happens, block altogether for the next 30s.
             return (synth(429, "Too Many Requests"));
         }
 
@@ -56,20 +63,24 @@ Example::
 
 $Event event_function
 
-$Function BOOL is_denied(STRING key, INT limit, DURATION period)
+$Function BOOL is_denied(STRING key, INT limit, DURATION period,
+                         DURATION block=0)
 
 Arguments:
 
   - key: A unique identifier to define what is being throttled - more examples below
   - limit: How many requests in the specified period
   - period: The time period
+  - block: a period to deny all access after meeting the threshold
 
 Description
   Can be used to rate limit the traffic for a specific key to a
-  maximum of 'limit' requests per 'period' time. A token bucket
-  is uniquely identified by the triplet of its key, limit and
-  period, so using the same key multiple places with different
-  rules will create multiple token buckets.
+  maximum of 'limit' requests per 'period' time. If 'block' is > 0s,
+  (0s by default), then always deny for 'key' for that length of time
+  after hitting the threshold. A token bucket is uniquely identified
+  by the 4-tuple of its key, limit, period and block, so using the
+  same key multiple places with different rules will create multiple
+  token buckets.
 
 Example
         ::
@@ -84,12 +95,14 @@ Example
 		}
 
 
-$Function INT remaining(STRING key, INT limit, DURATION period)
+$Function INT remaining(STRING key, INT limit, DURATION period,
+                        DURATION block=0)
 
 Arguments:
   - key: A unique identifier to define what is being throttled
   - limit: How many requests in the specified period
   - period: The time period
+  - block: duration to block, defaults to 0s
 
 Description
 


### PR DESCRIPTION
This changes the signature of ``is_denied()`` to add the ``block`` parameter:
```
BOOL is_denied(STRING key, INT limit, DURATION period, DURATION block=0)
```
When ``block`` > 0s, then after the threshold is reached, always return true for the duration of ``block``. This is a way to completely lock out a particularly troublesome client for a period of time, rather than letting them slip back in occasionally when the request rate slips below the threshold.

The default value of ``block`` is 0s. So existing deployments of the VMOD can continue using it without changes.

``block`` becomes one of the hashed elements that identify a token bucket. (Otherwise, different invocations with the same values for the other three params but with different blocks could pick up someone else's block, and get blocked spuriously.) So ``block`` is also a new optional param for ``remaining()``, also with the default value 0s.

Further add a new function ``blocked()``:
```
DURATION blocked(STRING key, INT limit, DURATION period, DURATION block)
```
For the token bucket identified by the four params, return the amount of time remaining in a pending block, or 0s if no block is pending.

We had to cook this up in a pinch to help a customer who was facing a DOS attack. The VMOD with these additions is running in production now and is doing what it's expected to do.

This PR contains a bit more commits than it needs to, and I'm willing to squash a few of them if you decide to accept it. You could also pick what parts you like.

The first commit adds the new param to ``is_denied()`` and ``remaining()``, and the third commit is a bugfix for it. These can be squashed.

The second commit adds the ``blocked()`` function, and the 5th and 6th commits are bugfixes that can be squashed with it.

The fourth commit changes the algorithm when a block is in effect. Originally, I had it just stop counting down tokens during that time, so the token countdown began anew when the block expired. With this change, the token countdown goes on during the block, so that if the request rate is high enough, a client may be immediately denied and blocked again after a block expires. So this aggressively locks out a client who keeps up a high request rate.

If you like it that way, the fourth commit can be squashed with the other ones for ``is_denied()`` and ``remaining()``.

So your choices are:

* Accept the whole PR
* Accept the additions to ``is_denied()`` and ``remaining()``, with or without the more aggressive blocking strategy.
* Accept the ``blocked()`` function as well.
* Reject the whole PR.

But I hope you like it. %^)