### PR TITLE
[xkey doc] Add example for use with space separated headers

### DIFF
--- a/docs/vmod_xkey.rst
+++ b/docs/vmod_xkey.rst
@@ -88,6 +88,9 @@ header for a certain page might look like this::
     xkey: 166412
     xkey: 234323
 
+Alternatively you may instead use a single header with space seperated
+values like `xkey: 8155054 166412 234323`.
+
 This requires a bit of VCL to be in place. The VCL can be found above.
 
 Then, in order to keep the web in sync with the database, a trigger is
@@ -98,6 +101,10 @@ with the matching xkey header::
     GET / HTTP/1.1
     Host: www.example.com
     xkey-purge: 166412
+
+Several `xkey-purge` headers are also supported like in reponse example above, and you
+may also here instead use a single header with space seperated values like
+`xkey-purge: 166412 234323`.
 
 Note the xkey-purge header. It is probably a good idea to protect
 this with an ACL so random people from the Internet cannot purge your


### PR DESCRIPTION
Adjusts docs for two things:
- That space separated values also work _(like in the original Surrogate-Key case)_
- Reflect that purge can take several values now _(since 0.10.2 in f723b4c25f292fcad85c9fac88e20d64e2d08ea0)_