### PR TITLE
Fix log message

### DIFF
--- a/src/vmod_tcp.c
+++ b/src/vmod_tcp.c
@@ -174,7 +174,7 @@ vmod_set_socket_pace(VRT_CTX, VCL_INT rate)
             sizeof(pacerate)) != 0)
                 VSLb(ctx->vsl, SLT_VCL_Error, "set_socket_pace(): Error setting pace rate.");
 	else
-                VSLb(ctx->vsl, SLT_VCL_Log, "vmod-tcp: Socket paced to %lu KB/s.", rate);
+                VSLb(ctx->vsl, SLT_VCL_Log, "vmod-tcp: Socket paced to %d KB/s.", pacerate);
 
 #  ifndef NDEBUG
         int retval;


### PR DESCRIPTION
Fixes log message - use correct variable in log message and correct format (on i686, I was not able to build varnish-modules):

vmod_tcp.c: In function 'vmod_set_socket_pace':
vmod_tcp.c:177:74: error: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'VCL_INT' {aka 'long long int'} [-Werror=format=]
                 VSLb(ctx->vsl, SLT_VCL_Log, "vmod-tcp: Socket paced to %lu KB/s.", rate);
                                                                        ~~^         ~~~~
                                                                        %llu