### PR TITLE
Xkey: Allow comma between keys per RFC2616

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -150,7 +150,8 @@ VMOD_TESTS = \
 	tests/xkey/test05.vtc \
 	tests/xkey/test06.vtc \
 	tests/xkey/test07.vtc \
-	tests/xkey/test08.vtc
+	tests/xkey/test08.vtc \
+	tests/xkey/test09.vtc
 
 SOFTPURGE_TESTS = \
 	tests/softpurge/01-load.vtc \

--- a/src/tests/xkey/test09.vtc
+++ b/src/tests/xkey/test09.vtc
@@ -1,0 +1,50 @@
+varnishtest "Test xkey vmod multiple keys, comma separated"
+# https://github.com/varnish/varnish-modules/issues/102
+
+server s1 {
+	rxreq
+	txresp -hdr "xkey: asdf, fdsa"
+} -start
+
+varnish v1 -vcl+backend {
+	import xkey from "${vmod_builddir}/.libs/libvmod_xkey.so";
+
+	sub vcl_recv {
+		if (req.http.xkey-purge) {
+			if (xkey.purge(req.http.xkey-purge) != 0) {
+				return (synth(200, "Purged"));
+			} else {
+				return (synth(404, "No key"));
+			}
+		}
+	}
+
+	sub vcl_backend_response {
+		set beresp.ttl = 60s;
+		set beresp.grace = 0s;
+		set beresp.keep = 0s;
+	}
+
+	sub vcl_synth {
+		set resp.http.reason = resp.reason;
+	}
+} -start
+
+client c1 {
+	txreq
+	rxresp
+} -run
+
+varnish v1 -expect n_object == 1
+
+client c1 {
+	# Test the purge using the asdf key, so we check that we didn't include the comma
+	txreq -hdr "xkey-purge: asdf"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.reason == "Purged"
+} -run
+
+delay 1
+
+varnish v1 -expect n_object == 0

--- a/src/tests/xkey/test09.vtc
+++ b/src/tests/xkey/test09.vtc
@@ -4,6 +4,9 @@ varnishtest "Test xkey vmod multiple keys, comma separated"
 server s1 {
 	rxreq
 	txresp -hdr "xkey: asdf, fdsa"
+
+	rxreq
+	txresp -hdr "xkey: qwer, rewq"
 } -start
 
 varnish v1 -vcl+backend {
@@ -33,13 +36,26 @@ varnish v1 -vcl+backend {
 client c1 {
 	txreq
 	rxresp
+	txreq -url /2
+	rxresp
 } -run
 
-varnish v1 -expect n_object == 1
+varnish v1 -expect n_object == 2
 
 client c1 {
 	# Test the purge using the asdf key, so we check that we didn't include the comma
 	txreq -hdr "xkey-purge: asdf"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.reason == "Purged"
+} -run
+
+delay 1
+
+varnish v1 -expect n_object == 1
+
+client c1 {
+	txreq -hdr "xkey-purge: rewq"
 	rxresp
 	expect resp.status == 200
 	expect resp.http.reason == "Purged"

--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -410,11 +410,11 @@ xkey_tok(const char **b, const char **e)
 	t = *b;
 	AN(t);
 
-	while (isblank(*t))
+	while (*t != ',' && isblank(*t))
 		t++;
 	*b = t;
 
-	while (*t != '\0' && !isblank(*t))
+	while (*t != '\0' && *t != ',' && !isblank(*t))
 		t++;
 	*e = t;
 	return (*b < *e);

--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -410,7 +410,7 @@ xkey_tok(const char **b, const char **e)
 	t = *b;
 	AN(t);
 
-	while (*t != ',' && isblank(*t))
+	while (*t == ',' || isblank(*t))
 		t++;
 	*b = t;
 


### PR DESCRIPTION
A possible fix for Issue #102

In this PR, I'm assuming that Varnish itself is handling folded header values for us.

One possible point where this may break from existing (invalid) assumptions is if an origin server is sending a surrogate key like "foo,bar", however RFC 2616 does suggest that this should be considered two separate headers having been combined into one.