### PR TITLE
vsthrottle: add return_token() function

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -143,6 +143,7 @@ VMOD_TESTS = \
 	tests/vsthrottle/test01.vtc \
 	tests/vsthrottle/test02.vtc \
 	tests/vsthrottle/test03.vtc \
+	tests/vsthrottle/test04.vtc \
 	tests/xkey/test01.vtc \
 	tests/xkey/test02.vtc \
 	tests/xkey/test03.vtc \

--- a/src/tests/vsthrottle/test04.vtc
+++ b/src/tests/vsthrottle/test04.vtc
@@ -1,0 +1,40 @@
+varnishtest "Test vsthrottle return_token()"
+
+server s1 {
+       rxreq
+       txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import vsthrottle from "${vmod_builddir}/.libs/libvmod_vsthrottle.so";
+
+	sub vcl_deliver {
+		set resp.http.foo-count0 = vsthrottle.remaining("foo", 1, 1s);
+		if (!vsthrottle.is_denied("foo", 1, 1s)) {
+			set resp.http.f1 = "OK";
+		}
+		set resp.http.foo-count1 = vsthrottle.remaining("foo", 1, 1s);
+
+		if (!vsthrottle.is_denied("foo", 1, 1s)) {
+			set resp.http.f2 = "OK";
+		}
+		set resp.http.foo-count2 = vsthrottle.remaining("foo", 1, 1s);
+
+		vsthrottle.return_token("foo", 1, 1s);
+
+		set resp.http.foo-count3 = vsthrottle.remaining("foo", 1, 1s);
+	}
+} -start
+
+client c1 {
+	txreq -url "/"
+	rxresp
+	expect resp.http.foo-count0 == "1"
+	expect resp.http.f1 == "OK"
+	expect resp.http.foo-count1 == "0"
+	expect resp.http.f2 == <undef>
+	expect resp.http.foo-count2 == "0"
+	expect resp.http.foo-count3 == "1"
+}
+
+client c1 -run

--- a/src/vmod_vsthrottle.c
+++ b/src/vmod_vsthrottle.c
@@ -205,6 +205,33 @@ vmod_is_denied(VRT_CTX, VCL_STRING key, VCL_INT limit, VCL_DURATION period,
 	return (ret);
 }
 
+VCL_VOID
+vmod_return_token(VRT_CTX, VCL_STRING key, VCL_INT limit, VCL_DURATION period,
+               VCL_DURATION block)
+{
+	struct tbucket *b;
+	double now;
+
+	struct vsthrottle *v;
+	unsigned char digest[SHA256_LEN];
+	unsigned part;
+
+	(void)ctx;
+
+	if (!key)
+		return;
+	do_digest(digest, key, limit, period, block);
+
+	part = digest[0] & N_PART_MASK;
+	v = &vsthrottle[part];
+	AZ(pthread_mutex_lock(&v->mtx));
+	now = VTIM_mono();
+	b = get_bucket(digest, limit, period, now);
+	b->tokens++;
+	calc_tokens(b, now);
+	AZ(pthread_mutex_unlock(&v->mtx));
+}
+
 /* Clean up expired entries. */
 static void
 run_gc(double now, unsigned part)

--- a/src/vmod_vsthrottle.c
+++ b/src/vmod_vsthrottle.c
@@ -228,7 +228,6 @@ vmod_return_token(VRT_CTX, VCL_STRING key, VCL_INT limit, VCL_DURATION period,
 	now = VTIM_mono();
 	b = get_bucket(digest, limit, period, now);
 	b->tokens++;
-	calc_tokens(b, now);
 	AZ(pthread_mutex_unlock(&v->mtx));
 }
 

--- a/src/vmod_vsthrottle.vcc
+++ b/src/vmod_vsthrottle.vcc
@@ -111,6 +111,11 @@ Description
   Note: This function doesn't enforce anything, it merely credits a token to
   appropriate bucket.
 
+  Warning: If streaming is enabled (beresp.do_stream = true) as it is by
+  default now, vcl_deliver() is called *before* the response is sent
+  to the client (who may download it slowly). Thus you may credit the token
+  back too early if you use return_token() in vcl_backend_response().
+
 Example
         ::
 

--- a/src/vmod_vsthrottle.vcc
+++ b/src/vmod_vsthrottle.vcc
@@ -95,6 +95,44 @@ Example
 		}
 
 
+$ABI vrt
+$Function VOID return_token(STRING key, INT limit, DURATION period,
+                         DURATION block=0)
+
+Arguments:
+
+  - key: A unique identifier to define what is being throttled - more examples below
+  - limit: How many requests in the specified period
+  - period: The time period
+  - block: a period to deny all access after meeting the threshold
+
+Description
+  Increment (by one) the number of tokens in the specified bucket. is_denied()
+  decrements the bucket by a token and return_token() adds it back.
+  Using these two, you can effectively make a token bucket act like a limit on
+  concurrent requests instead of requests / time.
+  Note: this function doesn't enforce anything, it merely credits a token to
+  appropriate bucket. A token bucket is uniquely identified by the 4-tuple of
+  its key, limit, period and block, so using the same key multiple places with
+  different rules will create multiple token buckets.
+
+Example
+        ::
+
+		sub vcl_recv {
+			if (vsthrottle.is_denied(client.identity, 20, 20s)) {
+				# Client has more than 20 concurrent requests
+				return (synth(429, "Too Many Requests In Flight"));
+			}
+
+			# ...
+		}
+
+		sub vcl_deliver {
+			vsthrottle.return_token(client.identity, 10, 10s);
+		}
+
+
 $Function INT remaining(STRING key, INT limit, DURATION period,
                         DURATION block=0)
 

--- a/src/vmod_vsthrottle.vcc
+++ b/src/vmod_vsthrottle.vcc
@@ -71,16 +71,17 @@ Arguments:
   - key: A unique identifier to define what is being throttled - more examples below
   - limit: How many requests in the specified period
   - period: The time period
-  - block: a period to deny all access after meeting the threshold
+  - block: a period to deny all access after hitting the threshold. Default is 0s
 
 Description
   Can be used to rate limit the traffic for a specific key to a
   maximum of 'limit' requests per 'period' time. If 'block' is > 0s,
   (0s by default), then always deny for 'key' for that length of time
-  after hitting the threshold. A token bucket is uniquely identified
-  by the 4-tuple of its key, limit, period and block, so using the
-  same key multiple places with different rules will create multiple
-  token buckets.
+  after hitting the threshold.
+
+  Note: A token bucket is uniquely identified by the 4-tuple of its
+  key, limit, period and block, so using the same key multiple places
+  with different rules will create multiple token buckets.
 
 Example
         ::
@@ -100,20 +101,19 @@ $Function VOID return_token(STRING key, INT limit, DURATION period,
 
 Arguments:
 
-  - key: A unique identifier to define what is being throttled - more examples below
-  - limit: How many requests in the specified period
-  - period: The time period
-  - block: a period to deny all access after meeting the threshold
+  - key: See is_denied()
+  - limit: See is_denied()
+  - period: See is_denied()
+  - block: See is_denied()
 
 Description
   Increment (by one) the number of tokens in the specified bucket. is_denied()
-  decrements the bucket by a token and return_token() adds it back.
+  decrements the bucket by one token and return_token() adds it back.
   Using these two, you can effectively make a token bucket act like a limit on
   concurrent requests instead of requests / time.
-  Note: this function doesn't enforce anything, it merely credits a token to
-  appropriate bucket. A token bucket is uniquely identified by the 4-tuple of
-  its key, limit, period and block, so using the same key multiple places with
-  different rules will create multiple token buckets.
+
+  Note: This function doesn't enforce anything, it merely credits a token to
+  appropriate bucket.
 
 Example
         ::
@@ -136,10 +136,10 @@ $Function INT remaining(STRING key, INT limit, DURATION period,
                         DURATION block=0)
 
 Arguments:
-  - key: A unique identifier to define what is being throttled
-  - limit: How many requests in the specified period
-  - period: The time period
-  - block: duration to block, defaults to 0s
+  - key: See is_denied()
+  - limit: See is_denied()
+  - period: See is_denied()
+  - block: See is_denied()
 
 Description
 
@@ -159,10 +159,10 @@ $Function DURATION blocked(STRING key, INT limit, DURATION period,
                            DURATION block)
 
 Arguments:
-  - key: A unique identifier to define what is being throttled
-  - limit: How many requests in the specified period
-  - period: The time period
-  - block: duration to block
+  - key: See is_denied()
+  - limit: See is_denied()
+  - period: See is_denied()
+  - block: See is_denied()
 
 Description
 

--- a/src/vmod_vsthrottle.vcc
+++ b/src/vmod_vsthrottle.vcc
@@ -100,11 +100,7 @@ $Function VOID return_token(STRING key, INT limit, DURATION period,
                          DURATION block=0)
 
 Arguments:
-
-  - key: See is_denied()
-  - limit: See is_denied()
-  - period: See is_denied()
-  - block: See is_denied()
+  - Same arguments as is_denied()
 
 Description
   Increment (by one) the number of tokens in the specified bucket. is_denied()
@@ -136,10 +132,7 @@ $Function INT remaining(STRING key, INT limit, DURATION period,
                         DURATION block=0)
 
 Arguments:
-  - key: See is_denied()
-  - limit: See is_denied()
-  - period: See is_denied()
-  - block: See is_denied()
+  - Same arguments as is_denied()
 
 Description
 
@@ -159,10 +152,7 @@ $Function DURATION blocked(STRING key, INT limit, DURATION period,
                            DURATION block)
 
 Arguments:
-  - key: See is_denied()
-  - limit: See is_denied()
-  - period: See is_denied()
-  - block: See is_denied()
+  - Same arguments as is_denied()
 
 Description
 

--- a/src/vmod_vsthrottle.vcc
+++ b/src/vmod_vsthrottle.vcc
@@ -95,7 +95,6 @@ Example
 		}
 
 
-$ABI vrt
 $Function VOID return_token(STRING key, INT limit, DURATION period,
                          DURATION block=0)
 


### PR DESCRIPTION
The docs explain it pretty well. With this, you can now limit
concurrency per bucket. Most servers are significantly contrained
in concurrency and a rate limit is most useful when your requests
all take the same amount of time / resources. When requests take
very different amount of resources / time, it's hard to find a rate
limit that is sensible.

Limiting concurrency instead will help you by prenting a trickle
of heavy long requests from burning you out.

Closes varnish/libvmod-vsthrottle#8