### PR TITLE
add header.dyn to create dynamic headers

### DIFF
--- a/src/tests/header/append.vtc
+++ b/src/tests/header/append.vtc
@@ -17,6 +17,7 @@ varnish v1 -vcl+backend {
 	sub vcl_backend_response {
 		if (bereq.url == "/foo") {
 			set beresp.http.foo = "null";
+			header.append(header.dyn(beresp, 35 + 7), "is the answer");
 		} elsif ( bereq.url == "/bar") {
 			header.append(beresp.http.foo, "blatti");
 		}
@@ -29,6 +30,7 @@ client c1 {
 	rxresp
 	expect resp.status == 200
 	expect resp.http.foo == "null"
+	expect resp.http.42 == "is the answer"
 } -run
 
 client c2 {

--- a/src/tests/header/get.vtc
+++ b/src/tests/header/get.vtc
@@ -18,8 +18,14 @@ varnish v1 -vcl+backend {
 	sub vcl_backend_response {
 		if (bereq.url == "/") {
 			set beresp.http.xusr = header.get(beresp.http.foo,"realcookie=");
+			set beresp.http.dyn-xusr = header.get(
+			    header.dyn(beresp,"foo"),
+			    "realcookie=");
 		} elsif (bereq.url == "/two") {
 			set beresp.http.xusr = header.get(beresp.http.foo,"^realcookie=");
+			set beresp.http.dyn-xusr = header.get(
+			    header.dyn(beresp,"foo"),
+			    "^realcookie=");
 		}
 		return(deliver);
 	}
@@ -30,11 +36,13 @@ client c1 {
 	rxresp
 	expect resp.status == 200
 	expect resp.http.xusr == "realcookie=YAI"
+	expect resp.http.dyn-xusr == "realcookie=YAI"
 
 	txreq -url "/two"
 	rxresp
 	expect resp.status == 200
 	expect resp.http.xusr == "realcookie=YAI"
+	expect resp.http.dyn-xusr == "realcookie=YAI"
 } -run
 
 

--- a/src/vmod_header.vcc
+++ b/src/vmod_header.vcc
@@ -102,6 +102,29 @@ Description
 Example
     :: header.regsub(req, "^(?i)Foo(\\d): (?-i)bar=(.*)$", "Bar\\1: \\2")
 
+$Function HEADER dyn(HTTP, STRING)
+
+Description
+        Return a dynamic header name.
+
+	Most other functions of this vmod require a *HEADER* argument,
+	which usually is a VCL-defined header like ``req.http.foo``.
+
+	This function allows to construct a header name from an
+	arbitrary string, which may also be dynamically created, for
+	example from a variable.
+
+	*Notice* that there are no syntactic checks on the *STRING*
+	argument by purpose in order to support exotic use cases. It
+	is entirely up to the user and at their own risk to supply a
+	string which represents a valid HTTP header name (or not).
+
+Example
+    ::
+    # create this request header
+    # 42: is the answer
+    header.append(header.dyn(req, 35 + 7), "is the answer");
+
 ACKNOWLEDGEMENTS
 ================
 


### PR DESCRIPTION
See also #147 

This solves the following use cases:
* construction of header names at vcl runtime
* use of header names not supported by vcl syntax