### PR TITLE
Plug regex leak in vmod_cookie

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -121,6 +121,7 @@ VMOD_TESTS = \
 	tests/cookie/31-get_regex.vtc \
 	tests/cookie/32-filter_regex.vtc \
 	tests/cookie/33-keep_regex.vtc \
+	tests/cookie/34-vcl_discard.vtc \
 	tests/cookie/r28.vtc \
 	tests/header/append.vtc \
 	tests/header/copy.vtc \

--- a/src/tests/cookie/34-vcl_discard.vtc
+++ b/src/tests/cookie/34-vcl_discard.vtc
@@ -1,0 +1,36 @@
+varnishtest "Test priv_call discard"
+
+server s1 -start
+
+varnish v1 -cliok "param.set thread_pools 1"
+varnish v1 -vcl+backend {
+	import cookie from "${vmod_builddir}/.libs/libvmod_cookie.so";
+	sub vcl_recv { return (synth(200)); }
+	sub vcl_synth {
+		cookie.set("cookie1", "value1");
+		cookie.set("cookie2", "value2");
+		cookie.set("cookie3", "value3");
+
+		cookie.filter_re("noop");
+		cookie.keep_re("cook");
+		set resp.http.get = cookie.get_re("cookie");
+	}
+} -start
+
+client c1 {
+	txreq -url "/"
+	rxresp
+	expect resp.http.get == value1
+} -run
+
+# load a new VCL to discard the first one
+varnish v1 -vcl+backend ""
+varnish v1 -cliok {vcl.discard vcl1}
+
+# tickle the CLI to trigger the effective VCL discard
+varnish v1 -cliok ping
+varnish v1 -expect n_vcl_avail == 1
+varnish v1 -expect n_vcl_discard == 0
+
+# tickle again, check we survived discard-time assertions
+varnish v1 -cliok ping

--- a/src/vmod_cookie.c
+++ b/src/vmod_cookie.c
@@ -242,6 +242,17 @@ compile_re(VRT_CTX, VCL_STRING expression) {
 	return(vre);
 }
 
+static void
+free_re(void *priv)
+{
+	vre_t *vre;
+
+	AN(priv);
+	vre = priv;
+	VRE_free(&vre);
+	AZ(vre);
+}
+
 VCL_STRING
 vmod_get_re(VRT_CTX, struct vmod_priv *priv, struct vmod_priv *priv_call,
     VCL_STRING expression)
@@ -265,7 +276,7 @@ vmod_get_re(VRT_CTX, struct vmod_priv *priv, struct vmod_priv *priv_call,
 		}
 
 		priv_call->priv = vre;
-		priv_call->free = free;
+		priv_call->free = free_re;
 		AZ(pthread_mutex_unlock(&mtx));
 	}
 
@@ -419,7 +430,7 @@ re_filter(VRT_CTX, struct vmod_priv *priv, struct vmod_priv *priv_call,
 		}
 
 		priv_call->priv = vre;
-		priv_call->free = free;
+		priv_call->free = free_re;
 		AZ(pthread_mutex_unlock(&mtx));
 	}
 

--- a/src/vmod_cookie.c
+++ b/src/vmod_cookie.c
@@ -51,10 +51,6 @@ enum filter_action {
 	whitelist = 1
 };
 
-vre_t * compile_re(VRT_CTX, VCL_STRING);
-VCL_VOID re_filter(VRT_CTX, struct vmod_priv *, struct vmod_priv *,
-    VCL_STRING, enum filter_action);
-
 static pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
 
 struct cookie {
@@ -231,7 +227,7 @@ vmod_get(VRT_CTX, struct vmod_priv *priv, VCL_STRING name)
 }
 
 
-vre_t *
+static vre_t *
 compile_re(VRT_CTX, VCL_STRING expression) {
 	vre_t *vre;
 	const char *error;
@@ -404,9 +400,9 @@ vmod_filter(VRT_CTX, struct vmod_priv *priv, VCL_STRING blacklist_s)
 }
 
 
-VCL_VOID
+static void
 re_filter(VRT_CTX, struct vmod_priv *priv, struct vmod_priv *priv_call,
-		  VCL_STRING expression, enum filter_action mode)
+    VCL_STRING expression, enum filter_action mode)
 {
 	struct vmod_cookie *vcp = cobj_get(priv);
 	struct cookie *current, *safeptr;


### PR DESCRIPTION
The PRIV_CALL regular expressions used to be leaked at vcl.discard time
and only the vre_t was freed.