### PR TITLE
Xkey bytes

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -162,7 +162,8 @@ VMOD_TESTS = \
 	tests/xkey/test08.vtc \
 	tests/xkey/test09.vtc \
 	tests/xkey/test10.vtc \
-	tests/xkey/test11.vtc
+	tests/xkey/test11.vtc \
+	tests/xkey/test12.vtc
 
 SOFTPURGE_TESTS = \
 	tests/softpurge/01-load.vtc \

--- a/src/tests/xkey/test12.vtc
+++ b/src/tests/xkey/test12.vtc
@@ -3,6 +3,8 @@ varnishtest "Test xkey bytes gauge"
 server s1 {
 	rxreq
 	txresp -hdr "xkey: asdf"
+	rxreq
+	txresp -hdr "xkey: fdsa"
 } -start
 
 varnish v1 -vcl+backend {
@@ -31,13 +33,21 @@ varnish v1 -vcl+backend {
 
 varnish v1 -expect XKEY.bytes == 0
 
-# First check xkey header
 client c1 {
 	txreq
 	rxresp
 } -run
 
-varnish v1 -expect XKEY.bytes == 1024
+varnish v1 -expect XKEY.bytes == 56
+
+client c1 {
+	txreq -url /something_longish
+	rxresp
+} -run
+
+delay 1
+
+varnish v1 -expect XKEY.bytes == 112
 
 client c1 {
 	txreq -hdr "xkey-purge: asdf"
@@ -46,6 +56,4 @@ client c1 {
 	expect resp.http.reason == "Purged"
 } -run
 
-delay 1
-
-varnish v1 -expect XKEY.bytes == 0
+varnish v1 -expect XKEY.bytes == 56

--- a/src/tests/xkey/test12.vtc
+++ b/src/tests/xkey/test12.vtc
@@ -60,7 +60,8 @@ varnish v1 -vcl+backend {
 # no cache, no xkeys
 varnish v1 -expect XKEY.g_hashhead_bytes == 0  \
            -expect XKEY.g_ochead_bytes == 0 \
-           -expect XKEY.g_oc_bytes == 0
+           -expect XKEY.g_oc_bytes == 0 \
+           -expect XKEY.g_bytes == 0
 
 client c1 {
 	txreq
@@ -70,7 +71,8 @@ client c1 {
 # one cached response, one xkey
 varnish v1 -expect XKEY.g_hashhead_bytes == 104 \
            -expect XKEY.g_ochead_bytes == 80 \
-           -expect XKEY.g_oc_bytes == 56
+           -expect XKEY.g_oc_bytes == 56 \
+           -expect XKEY.g_bytes == 240
 
 client c1 {
 	txreq -url /something_longish
@@ -80,7 +82,8 @@ client c1 {
 # two cached responses, two xkeys
 varnish v1 -expect XKEY.g_hashhead_bytes == 208 \
            -expect XKEY.g_ochead_bytes == 160 \
-           -expect XKEY.g_oc_bytes == 112
+           -expect XKEY.g_oc_bytes == 112 \
+           -expect XKEY.g_bytes == 480
 
 client c1 {
 	txreq -url /something_else
@@ -90,7 +93,8 @@ client c1 {
 # three cached responses, two xkeys
 varnish v1 -expect XKEY.g_hashhead_bytes == 208 \
            -expect XKEY.g_ochead_bytes == 240 \
-           -expect XKEY.g_oc_bytes == 168
+           -expect XKEY.g_oc_bytes == 168 \
+           -expect XKEY.g_bytes == 616
 
 client c1 {
 	txreq -hdr "xkey-purge: asdf"
@@ -102,4 +106,5 @@ client c1 {
 # one cached response, one xkey
 varnish v1 -expect XKEY.g_hashhead_bytes == 104 \
            -expect XKEY.g_ochead_bytes == 80 \
-           -expect XKEY.g_oc_bytes == 56
+           -expect XKEY.g_oc_bytes == 56 \
+           -expect XKEY.g_bytes == 240

--- a/src/tests/xkey/test12.vtc
+++ b/src/tests/xkey/test12.vtc
@@ -34,28 +34,8 @@ varnish v1 -vcl+backend {
 } -start
 
 # g_hashhead_bytes  = 104 bytes per xkey
-#
-# head->key         = 64 bytes # the actual hash of the key
-# head->magic       =  4 bytes # some kind of "magic"
-# head->list        = 16 bytes # just need size of pointer
-# head->ocs         = 16 bytes # just need size of pointer
-# alignment         =  4 bytes # makes multiples of 8
-
 # g_ochead_bytes    = 80 bytes per cached object
-#
-# ochead->key       = 40 bytes # xkey_ptrkey + rbt entry
-# ochead->magic     =  4 bytes # some kind of "magic"
-# ochead->list      = 16 bytes # tailq entry w/2 pointers
-# ochead->ocs       = 16 bytes # tailq head w/2 pointers
-
 # g_oc_bytes        = 56 bytes per cached object
-#
-# oc->magic         =  4 bytes # some kind of "magic"
-# oc->list_ochead   = 16 bytes # tailq entry w/2 pointers
-# oc->list_hashhead = 16 bytes # tailq entry w/2 pointers
-# oc->hashhead      =  8 bytes # just need size of pointer
-# oc->objcore       =  8 # just need size of pointer
-# alignment         =  4 bytes # makes multiples of 8
 
 # no cache, no xkeys
 varnish v1 -expect XKEY.g_hashhead_bytes == 0  \

--- a/src/tests/xkey/test12.vtc
+++ b/src/tests/xkey/test12.vtc
@@ -5,6 +5,8 @@ server s1 {
 	txresp -hdr "xkey: asdf"
 	rxreq
 	txresp -hdr "xkey: fdsa"
+	rxreq
+	txresp -hdr "xkey: asdf"
 } -start
 
 varnish v1 -vcl+backend {
@@ -31,27 +33,64 @@ varnish v1 -vcl+backend {
 	}
 } -start
 
-# TODO: use these tests to interrogate the head object where
-# we += the size(head) in the code now. Make comments indicating
-# expected object/component sizes. Total should be 104 per hashhead
+# g_hashhead_bytes  = 104 bytes per xkey
+#
+# head->key         = 64 bytes # the actual hash of the key
+# head->magic       =  4 bytes # some kind of "magic"
+# head->list        = 16 bytes # just need size of pointer
+# head->ocs         = 16 bytes # just need size of pointer
+# alignment         =  4 bytes # makes multiples of 8
 
-varnish v1 -expect XKEY.g_hashhead == 0
+# g_ochead_bytes    = 80 bytes per cached object
+#
+# ochead->key       = 40 bytes # xkey_ptrkey + rbt entry
+# ochead->magic     =  4 bytes # some kind of "magic"
+# ochead->list      = 16 bytes # tailq entry w/2 pointers
+# ochead->ocs       = 16 bytes # tailq head w/2 pointers
+
+# g_oc_bytes        = 56 bytes per cached object
+#
+# oc->magic         =  4 bytes # some kind of "magic"
+# oc->list_ochead   = 16 bytes # tailq entry w/2 pointers
+# oc->list_hashhead = 16 bytes # tailq entry w/2 pointers
+# oc->hashhead      =  8 bytes # just need size of pointer
+# oc->objcore       =  8 # just need size of pointer
+# alignment         =  4 bytes # makes multiples of 8
+
+# no cache, no xkeys
+varnish v1 -expect XKEY.g_hashhead_bytes == 0  \
+           -expect XKEY.g_ochead_bytes == 0 \
+           -expect XKEY.g_oc_bytes == 0
 
 client c1 {
 	txreq
 	rxresp
 } -run
 
-varnish v1 -expect XKEY.g_hashhead == 104
+# one cached response, one xkey
+varnish v1 -expect XKEY.g_hashhead_bytes == 104 \
+           -expect XKEY.g_ochead_bytes == 80 \
+           -expect XKEY.g_oc_bytes == 56
 
 client c1 {
 	txreq -url /something_longish
 	rxresp
 } -run
 
-delay 1
+# two cached responses, two xkeys
+varnish v1 -expect XKEY.g_hashhead_bytes == 208 \
+           -expect XKEY.g_ochead_bytes == 160 \
+           -expect XKEY.g_oc_bytes == 112
 
-varnish v1 -expect XKEY.g_hashhead == 208
+client c1 {
+	txreq -url /something_else
+	rxresp
+} -run
+
+# three cached responses, two xkeys
+varnish v1 -expect XKEY.g_hashhead_bytes == 208 \
+           -expect XKEY.g_ochead_bytes == 240 \
+           -expect XKEY.g_oc_bytes == 168
 
 client c1 {
 	txreq -hdr "xkey-purge: asdf"
@@ -60,4 +99,7 @@ client c1 {
 	expect resp.http.reason == "Purged"
 } -run
 
-varnish v1 -expect XKEY.g_hashhead == 104
+# one cached response, one xkey
+varnish v1 -expect XKEY.g_hashhead_bytes == 104 \
+           -expect XKEY.g_ochead_bytes == 80 \
+           -expect XKEY.g_oc_bytes == 56

--- a/src/tests/xkey/test12.vtc
+++ b/src/tests/xkey/test12.vtc
@@ -1,0 +1,51 @@
+varnishtest "Test xkey bytes gauge"
+
+server s1 {
+	rxreq
+	txresp -hdr "xkey: asdf"
+} -start
+
+varnish v1 -vcl+backend {
+	import xkey from "${vmod_builddir}/.libs/libvmod_xkey.so";
+
+	sub vcl_recv {
+		if (req.http.xkey-purge) {
+			if (xkey.purge(req.http.xkey-purge) != 0) {
+				return (synth(200, "Purged"));
+			} else {
+				return (synth(404, "No key"));
+			}
+		}
+	}
+
+	sub vcl_backend_response {
+		set beresp.ttl = 60s;
+		set beresp.grace = 0s;
+		set beresp.keep = 0s;
+	}
+
+	sub vcl_synth {
+		set resp.http.reason = resp.reason;
+	}
+} -start
+
+varnish v1 -expect XKEY.bytes == 0
+
+# First check xkey header
+client c1 {
+	txreq
+	rxresp
+} -run
+
+varnish v1 -expect XKEY.bytes == 1024
+
+client c1 {
+	txreq -hdr "xkey-purge: asdf"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.reason == "Purged"
+} -run
+
+delay 1
+
+varnish v1 -expect XKEY.bytes == 0

--- a/src/tests/xkey/test12.vtc
+++ b/src/tests/xkey/test12.vtc
@@ -31,14 +31,18 @@ varnish v1 -vcl+backend {
 	}
 } -start
 
-varnish v1 -expect XKEY.bytes == 0
+# TODO: use these tests to interrogate the head object where
+# we += the size(head) in the code now. Make comments indicating
+# expected object/component sizes. Total should be 104 per hashhead
+
+varnish v1 -expect XKEY.g_hashhead == 0
 
 client c1 {
 	txreq
 	rxresp
 } -run
 
-varnish v1 -expect XKEY.bytes == 56
+varnish v1 -expect XKEY.g_hashhead == 104
 
 client c1 {
 	txreq -url /something_longish
@@ -47,7 +51,7 @@ client c1 {
 
 delay 1
 
-varnish v1 -expect XKEY.bytes == 112
+varnish v1 -expect XKEY.g_hashhead == 208
 
 client c1 {
 	txreq -hdr "xkey-purge: asdf"
@@ -56,4 +60,4 @@ client c1 {
 	expect resp.http.reason == "Purged"
 } -run
 
-varnish v1 -expect XKEY.bytes == 56
+varnish v1 -expect XKEY.g_hashhead == 104

--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -282,9 +282,8 @@ xkey_hashtree_insert(const unsigned char *digest, unsigned len)
 	if (key != NULL) {
 		xkey_hashhead_delete(&head);
 		CAST_OBJ_NOTNULL(head, (void *)key, XKEY_HASHHEAD_MAGIC);
-	} else {
+	} else 
 		vsc->g_keys++;
-	}
 	return (head);
 }
 

--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -270,8 +270,10 @@ xkey_hashtree_insert(const unsigned char *digest, unsigned len)
 	if (key != NULL) {
 		xkey_hashhead_delete(&head);
 		CAST_OBJ_NOTNULL(head, (void *)key, XKEY_HASHHEAD_MAGIC);
-	} else
+	} else {
 		vsc->g_keys++;
+		vsc->g_bytes += sizeof(*oc);
+	}
 	return (head);
 }
 
@@ -351,6 +353,7 @@ xkey_remove(struct xkey_ochead **pochead)
 			    &hashhead->key);
 			xkey_hashhead_delete(&hashhead);
 			vsc->g_keys--;
+			vsc->g_bytes -= sizeof(*oc);
 		}
 		oc->objcore = NULL;
 		VTAILQ_REMOVE(&ochead->ocs, oc, list_ochead);

--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -153,6 +153,7 @@ xkey_hashhead_new(void)
 		VTAILQ_INIT(&head->ocs);
 	}
 	vsc->g_hashhead_bytes += sizeof(*head);
+	vsc->g_bytes += sizeof(*head);
 	return (head);
 }
 
@@ -166,6 +167,7 @@ xkey_hashhead_delete(struct xkey_hashhead **phead)
 	CHECK_OBJ_NOTNULL(head, XKEY_HASHHEAD_MAGIC);
 	AN(VTAILQ_EMPTY(&head->ocs));
 	vsc->g_hashhead_bytes -= sizeof(*head);
+	vsc->g_bytes -= sizeof(*head);
 	if (xkey_pool.n_hashhead < POOL_MAX) {
 		memset(&head->key, 0, sizeof(head->key));
 		VTAILQ_INSERT_HEAD(&xkey_pool.hashheads, head, list);
@@ -190,6 +192,7 @@ xkey_ochead_new(void)
 		VTAILQ_INIT(&head->ocs);
 	}
 	vsc->g_ochead_bytes += sizeof(*head);
+	vsc->g_bytes += sizeof(*head);
 	return (head);
 }
 
@@ -203,6 +206,7 @@ xkey_ochead_delete(struct xkey_ochead **phead)
 	CHECK_OBJ_NOTNULL(head, XKEY_OCHEAD_MAGIC);
 	AN(VTAILQ_EMPTY(&head->ocs));
 	vsc->g_ochead_bytes -= sizeof(*head);
+	vsc->g_bytes -= sizeof(*head);
 	if (xkey_pool.n_ochead < POOL_MAX) {
 		memset(&head->key, 0, sizeof(head->key));
 		VTAILQ_INSERT_HEAD(&xkey_pool.ocheads, head, list);
@@ -225,6 +229,7 @@ xkey_oc_new(void)
 		ALLOC_OBJ(oc, XKEY_OC_MAGIC);
 		AN(oc);
 		vsc->g_oc_bytes += sizeof(*oc);
+		vsc->g_bytes += sizeof(*oc);
 	}
 	return (oc);
 }
@@ -239,6 +244,7 @@ xkey_oc_delete(struct xkey_oc **poc)
 	CHECK_OBJ_NOTNULL(oc, XKEY_OC_MAGIC);
 	AZ(oc->objcore);
 	vsc->g_oc_bytes -= sizeof(*oc);
+	vsc->g_bytes -= sizeof(*oc);
 	if (xkey_pool.n_oc < POOL_MAX) {
 		VTAILQ_INSERT_HEAD(&xkey_pool.ocs, oc, list_hashhead);
 		xkey_pool.n_oc++;

--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -272,7 +272,7 @@ xkey_hashtree_insert(const unsigned char *digest, unsigned len)
 		CAST_OBJ_NOTNULL(head, (void *)key, XKEY_HASHHEAD_MAGIC);
 	} else {
 		vsc->g_keys++;
-		vsc->g_bytes += sizeof(*oc);
+		vsc->g_hashhead += sizeof(*head);
 	}
 	return (head);
 }
@@ -353,7 +353,7 @@ xkey_remove(struct xkey_ochead **pochead)
 			    &hashhead->key);
 			xkey_hashhead_delete(&hashhead);
 			vsc->g_keys--;
-			vsc->g_bytes -= sizeof(*oc);
+			vsc->g_hashhead -= sizeof(*hashhead);
 		}
 		oc->objcore = NULL;
 		VTAILQ_REMOVE(&ochead->ocs, oc, list_ochead);

--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -152,6 +152,7 @@ xkey_hashhead_new(void)
 		AN(head);
 		VTAILQ_INIT(&head->ocs);
 	}
+	vsc->g_hashhead_bytes += sizeof(*head);
 	return (head);
 }
 
@@ -164,6 +165,7 @@ xkey_hashhead_delete(struct xkey_hashhead **phead)
 	*phead = NULL;
 	CHECK_OBJ_NOTNULL(head, XKEY_HASHHEAD_MAGIC);
 	AN(VTAILQ_EMPTY(&head->ocs));
+	vsc->g_hashhead_bytes -= sizeof(*head);
 	if (xkey_pool.n_hashhead < POOL_MAX) {
 		memset(&head->key, 0, sizeof(head->key));
 		VTAILQ_INSERT_HEAD(&xkey_pool.hashheads, head, list);
@@ -187,6 +189,7 @@ xkey_ochead_new(void)
 		AN(head);
 		VTAILQ_INIT(&head->ocs);
 	}
+	vsc->g_ochead_bytes += sizeof(*head);
 	return (head);
 }
 
@@ -199,6 +202,7 @@ xkey_ochead_delete(struct xkey_ochead **phead)
 	*phead = NULL;
 	CHECK_OBJ_NOTNULL(head, XKEY_OCHEAD_MAGIC);
 	AN(VTAILQ_EMPTY(&head->ocs));
+	vsc->g_ochead_bytes -= sizeof(*head);
 	if (xkey_pool.n_ochead < POOL_MAX) {
 		memset(&head->key, 0, sizeof(head->key));
 		VTAILQ_INSERT_HEAD(&xkey_pool.ocheads, head, list);
@@ -220,6 +224,7 @@ xkey_oc_new(void)
 	} else {
 		ALLOC_OBJ(oc, XKEY_OC_MAGIC);
 		AN(oc);
+		vsc->g_oc_bytes += sizeof(*oc);
 	}
 	return (oc);
 }
@@ -233,6 +238,7 @@ xkey_oc_delete(struct xkey_oc **poc)
 	*poc = NULL;
 	CHECK_OBJ_NOTNULL(oc, XKEY_OC_MAGIC);
 	AZ(oc->objcore);
+	vsc->g_oc_bytes -= sizeof(*oc);
 	if (xkey_pool.n_oc < POOL_MAX) {
 		VTAILQ_INSERT_HEAD(&xkey_pool.ocs, oc, list_hashhead);
 		xkey_pool.n_oc++;
@@ -272,7 +278,6 @@ xkey_hashtree_insert(const unsigned char *digest, unsigned len)
 		CAST_OBJ_NOTNULL(head, (void *)key, XKEY_HASHHEAD_MAGIC);
 	} else {
 		vsc->g_keys++;
-		vsc->g_hashhead += sizeof(*head);
 	}
 	return (head);
 }
@@ -353,7 +358,6 @@ xkey_remove(struct xkey_ochead **pochead)
 			    &hashhead->key);
 			xkey_hashhead_delete(&hashhead);
 			vsc->g_keys--;
-			vsc->g_hashhead -= sizeof(*hashhead);
 		}
 		oc->objcore = NULL;
 		VTAILQ_REMOVE(&ochead->ocs, oc, list_ochead);

--- a/src/xkey.vsc
+++ b/src/xkey.vsc
@@ -11,6 +11,21 @@
 
 	Number of surrogate keys in use. Increases after a request that includes a new key in the xkey header. Decreases when a key is purged or when all cache objects associated with a key expire.
 
+.. varnish_vsc:: g_hashhead
+	:type:		gauge
+	:level:		debug
+	:oneliner:  Bytes used by all xkey_hashhead objects
+
+.. varnish_vsc:: g_ochead
+	:type:		gauge
+	:level:		debug
+	:oneliner:  Bytes used by all xkey_ochead objects
+
+.. varnish_vsc:: g_oc
+	:type:		gauge
+	:level:		debug
+	:oneliner:  Bytes used by all xkey_oc objects
+
 .. varnish_vsc:: g_bytes
 	:type:		gauge
 	:oneliner:  Bytes used by xkeys

--- a/src/xkey.vsc
+++ b/src/xkey.vsc
@@ -11,4 +11,10 @@
 
 	Number of surrogate keys in use. Increases after a request that includes a new key in the xkey header. Decreases when a key is purged or when all cache objects associated with a key expire.
 
+.. varnish_vsc:: bytes
+	:type:		gauge
+	:oneliner:  Bytes used by xkeys
+
+	Current size of the memory used by xkeys
+
 .. varnish_vsc_end::	xkey

--- a/src/xkey.vsc
+++ b/src/xkey.vsc
@@ -11,7 +11,7 @@
 
 	Number of surrogate keys in use. Increases after a request that includes a new key in the xkey header. Decreases when a key is purged or when all cache objects associated with a key expire.
 
-.. varnish_vsc:: bytes
+.. varnish_vsc:: g_bytes
 	:type:		gauge
 	:oneliner:  Bytes used by xkeys
 

--- a/src/xkey.vsc
+++ b/src/xkey.vsc
@@ -11,17 +11,17 @@
 
 	Number of surrogate keys in use. Increases after a request that includes a new key in the xkey header. Decreases when a key is purged or when all cache objects associated with a key expire.
 
-.. varnish_vsc:: g_hashhead
+.. varnish_vsc:: g_hashhead_bytes
 	:type:		gauge
 	:level:		debug
 	:oneliner:  Bytes used by all xkey_hashhead objects
 
-.. varnish_vsc:: g_ochead
+.. varnish_vsc:: g_ochead_bytes
 	:type:		gauge
 	:level:		debug
 	:oneliner:  Bytes used by all xkey_ochead objects
 
-.. varnish_vsc:: g_oc
+.. varnish_vsc:: g_oc_bytes
 	:type:		gauge
 	:level:		debug
 	:oneliner:  Bytes used by all xkey_oc objects

--- a/src/xkey.vsc
+++ b/src/xkey.vsc
@@ -16,20 +16,26 @@
 	:level:		debug
 	:oneliner:  Bytes used by all xkey_hashhead objects
 
+	Total bytes used by hashhead objects. Tracks linearly with the number of surrogate keys in use.
+
 .. varnish_vsc:: g_ochead_bytes
 	:type:		gauge
 	:level:		debug
 	:oneliner:  Bytes used by all xkey_ochead objects
+
+	Total bytes used by ochead objects. Increases when an object is added to a key or a key is added to an object. Decreases when the relationship is removed.
 
 .. varnish_vsc:: g_oc_bytes
 	:type:		gauge
 	:level:		debug
 	:oneliner:  Bytes used by all xkey_oc objects
 
+	Total bytes used by oc objects. Tracks linearly with the number of cached objects that are referenced by surrogate keys.
+
 .. varnish_vsc:: g_bytes
 	:type:		gauge
 	:oneliner:  Bytes used by xkeys
 
-	Current size of the memory used by xkeys
+	Current number of bytes used by xkeys and their references to the object cache.
 
 .. varnish_vsc_end::	xkey


### PR DESCRIPTION
Adds gauges for bytes used by vmod_xkey's data structures

Co-Authored-By: Ben Zvan <ben.zvan@target.com>