### PR TITLE
Update documentation of vmod_var variable types

### DIFF
--- a/docs/vmod_var.rst
+++ b/docs/vmod_var.rst
@@ -56,11 +56,12 @@ SYNOPSIS
    
 This VMOD implements basic variable support in VCL.
 
-It supports strings, integers and real numbers. There are methods to get and
-set each data type.
+It supports strings, integers, real numbers, durations, IP addresses
+and backends. There are methods to get and set each data type.
 
 Global variables have a lifespan that extends across requests and
-VCLs, for as long as the vmod is loaded.
+VCLs, for as long as the vmod is loaded. Global variables only support
+strings.
 
 The remaining functions have PRIV_TASK lifespan and are local to a single
 request or backend request.

--- a/src/vmod_var.vcc
+++ b/src/vmod_var.vcc
@@ -2,11 +2,12 @@ $Module var 3 "Variable support for Varnish VCL"
 
 This VMOD implements basic variable support in VCL.
 
-It supports strings, integers and real numbers. There are methods to get and
-set each data type.
+It supports strings, integers, real numbers, durations, IP addresses
+and backends. There are methods to get and set each data type.
 
 Global variables have a lifespan that extends across requests and
-VCLs, for as long as the vmod is loaded.
+VCLs, for as long as the vmod is loaded. Global variables only support
+strings.
 
 The remaining functions have PRIV_TASK lifespan and are local to a single
 request or backend request.


### PR DESCRIPTION
The module supports durations, ip addresses and backends which was not
listed in the documentation header. Also clarify that global variables
are string only.