### PR TITLE
Revert "Construct intermediate strands on the stack" commit

### DIFF
--- a/src/vmod_header.c
+++ b/src/vmod_header.c
@@ -173,18 +173,20 @@ VCL_VOID
 vmod_append(VRT_CTX, VCL_HEADER hdr, VCL_STRANDS s)
 {
 	struct http *hp;
-	struct strands st[1];
-	const char *p[s->n + 2];
+	struct strands *st;
 	const char *b;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 
 	/* prefix the strand with $hdr_name + space */
-	p[0] = hdr->what + 1;
-	p[1] = " ";
-	AN(memcpy(p + 2, s->p, s->n * sizeof *s->p));
-	st->n = s->n + 2;
-	st->p = p;
+	st = VRT_AllocStrandsWS(ctx->ws, s->n + 2);
+	if (!st) {
+		VRT_fail(ctx, "vmod_head: workspace allocation failure");
+		return;
+	}
+	st->p[0] = hdr->what + 1;
+	st->p[1] = " ";
+	AN(memcpy(st->p + 2, s->p, s->n * sizeof *s->p));
 
 	b = VRT_StrandsWS(ctx->ws, NULL, st);
 	if (b == NULL) {


### PR DESCRIPTION
This reverts 81231af3295e1464574cda4dfac238b548e08c19. I believe its not accepted practice to do dynamic stack allocations like this. In this case, there are no bounds checks and also, as with all stack allocations, no way to detect a stack overflow or failure (aside from getting a segfault).