### PR TITLE
fix(vmod_var): gracefully handle WS_Alloc failures

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -139,6 +139,7 @@ VMOD_TESTS = \
 	tests/var/test03.vtc \
 	tests/var/test04.vtc \
 	tests/var/test05.vtc \
+	tests/var/test06.vtc \
 	tests/vsthrottle/test01.vtc \
 	tests/vsthrottle/test02.vtc \
 	tests/vsthrottle/test03.vtc \

--- a/src/tests/var/test06.vtc
+++ b/src/tests/var/test06.vtc
@@ -1,0 +1,48 @@
+varnishtest "Test that running out of workspace memory fails the request"
+
+server s1 {
+	rxreq
+	txresp
+	rxreq
+	txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import var from "${vmod_builddir}/.libs/libvmod_var.so";
+        import vtc;
+
+	sub vcl_deliver {
+               if (req.url == "/a") {
+                   # Leave only a single byte in the workspace free.
+                   vtc.workspace_alloc(client, -1);
+                   # The allocation of the the actual struct var is next and will fail now.
+                   var.set("a", "0");
+               }
+               if (req.url == "/b") {
+                   # Leave enough bytes in the workspace for the
+                   # struct var allocation to succeed, but fail when
+                   # copying the variable name.
+                   vtc.workspace_alloc(client, -64);
+                   var.set("b000000000000000000000000000000000000000000000000000000000000000", "0");
+               }
+	}
+} -start
+
+logexpect l1 -v v1 {
+	expect * * VCL_Error "vmod_var: alloc var: out of workspace"
+	expect * * VCL_Error "vmod_var: copy name: out of workspace"
+} -start
+
+client c1 {
+	txreq -url "/a"
+	rxresp
+	expect resp.status >= 500
+} -run
+
+client c1 {
+	txreq -url "/b"
+	rxresp
+	expect resp.status >= 500
+} -run
+
+logexpect l1 -wait

--- a/src/vmod_var.c
+++ b/src/vmod_var.c
@@ -109,10 +109,18 @@ vh_get_var_alloc(struct var_head *vh, const char *name, const struct vrt_ctx *ct
 	if (!v) {
 		/* Allocate and add */
 		v = (struct var*)WS_Alloc(ctx->ws, sizeof(struct var));
-		AN(v);
+		if (v == NULL)
+		{
+			VRT_fail(ctx, "vmod_var: alloc var: out of workspace");
+			return NULL;
+		}
 		v->magic = VAR_MAGIC;
 		v->name = WS_Copy(ctx->ws, name, -1);
-		AN(v->name);
+		if (v->name == NULL)
+                {
+			VRT_fail(ctx, "vmod_var: copy name: out of workspace");
+			return NULL;
+		}
 		VTAILQ_INSERT_HEAD(&vh->vars, v, list);
 	}
 	return v;
@@ -172,7 +180,8 @@ vmod_set_string(const struct vrt_ctx *ctx, struct vmod_priv *priv,
 	if (name == NULL)
 		return;
 	v = vh_get_var_alloc(get_vh(priv), name, ctx);
-	AN(v);
+	if (v == NULL)
+		return;
 	v->type = STRING;
 	if (value == NULL)
 		value = "";
@@ -204,7 +213,8 @@ vmod_set_ip(const struct vrt_ctx *ctx, struct vmod_priv *priv, VCL_STRING name,
 	if (name == NULL)
 		return;
 	v = vh_get_var_alloc(get_vh(priv), name, ctx);
-	AN(v);
+	if (v == NULL)
+		return;
 	v->type = IP;
 	AN(ip);
 	v->value.IP = WS_Copy(ctx->ws, ip, vsa_suckaddr_len);;
@@ -234,7 +244,8 @@ vmod_set_##vcl_type_l(const struct vrt_ctx *ctx, struct vmod_priv *priv,\
 	if (name == NULL)						\
 		return;							\
 	v = vh_get_var_alloc(get_vh(priv), name, ctx);			\
-	AN(v);								\
+	if (v == NULL)                                                  \
+		return;                                                 \
 	v->type = vcl_type_u;						\
 	v->value.vcl_type_u = value;					\
 }


### PR DESCRIPTION
The assumption that `WS_Alloc` always returns a non-NULL value is not
true, which can lead to the `AN(v)` following the call to `WS_Alloc` in
`vmod_var` to kill the varnish child process, resulting in a loss of the
cache.

Instead of panicking due to a failed assertion, this commit introduces a
check of the return value of `WS_Alloc` and fails the request in case
not enough memory was available for allocating a new variable.

Follow-up for #196 