### PR TITLE
Add vsthrottle.remove_bucket()

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -144,6 +144,7 @@ VMOD_TESTS = \
 	tests/vsthrottle/test02.vtc \
 	tests/vsthrottle/test03.vtc \
 	tests/vsthrottle/test04.vtc \
+	tests/vsthrottle/test05.vtc \
 	tests/xkey/test01.vtc \
 	tests/xkey/test02.vtc \
 	tests/xkey/test03.vtc \

--- a/src/tests/vsthrottle/test05.vtc
+++ b/src/tests/vsthrottle/test05.vtc
@@ -1,0 +1,44 @@
+varnishtest "Test vsthrottle remove_bucket()"
+
+server s1 {
+       rxreq
+       txresp
+} -start
+
+varnish v1 -vcl+backend {
+	import vsthrottle from "${vmod_builddir}/.libs/libvmod_vsthrottle.so";
+
+	sub vcl_deliver {
+		set resp.http.foo-count0 = vsthrottle.remaining("foo", 5, 1s);
+		if (!vsthrottle.is_denied("foo", 5, 1s)) {
+			set resp.http.f1 = "OK";
+		}
+
+		if (!vsthrottle.is_denied("foo", 5, 1s)) {
+			set resp.http.f2 = "OK";
+		}
+
+		if (!vsthrottle.is_denied("foo", 5, 1s)) {
+			set resp.http.f3 = "OK";
+		}
+
+		set resp.http.foo-count1 = vsthrottle.remaining("foo", 5, 1s);
+
+		vsthrottle.remove_bucket("foo", 5, 1s);
+
+		set resp.http.foo-count2 = vsthrottle.remaining("foo", 5, 1s);
+	}
+} -start
+
+client c1 {
+	txreq -url "/"
+	rxresp
+	expect resp.http.foo-count0 == "5"
+	expect resp.http.f1 == "OK"
+	expect resp.http.f2 == "OK"
+	expect resp.http.f3 == "OK"
+	expect resp.http.foo-count1 == "2"
+	expect resp.http.foo-count2 == "5"
+}
+
+client c1 -run

--- a/src/vmod_vsthrottle.vcc
+++ b/src/vmod_vsthrottle.vcc
@@ -175,3 +175,21 @@ Example
 	set resp.http.Retry-After
 		= vsthrottle.blocked(client.identity, 15, 10s, 30s);
      }
+
+$Function VOID remove_bucket(STRING key, INT limit, DURATION period,
+                           DURATION block=0)
+
+Arguments:
+  - Same arguments as is_denied()
+
+Description
+
+  Remove the token bucket identified by the four parameters, if it exists.
+
+
+Example
+  ::
+
+     sub vcl_deliver {
+	    vsthrottle.remove_bucket(client.identity, 15, 10s, 30s);
+     }


### PR DESCRIPTION
VOID remove_bucket(STRING key, INT limit, DURATION period, DURATION block)

Arguments:
  - Same arguments as is_denied()

Description

  Remove the token bucket identified by the four parameters, if it exists.

Example:

     sub vcl_deliver {
	    vsthrottle.remove_bucket(client.identity, 15, 10s, 30s);
     }

it fixes the issue #204 