### PR TITLE
Add check for block parameter in run_gc

### DIFF
--- a/src/vmod_vsthrottle.c
+++ b/src/vmod_vsthrottle.c
@@ -241,7 +241,7 @@ run_gc(double now, unsigned part)
 	/* XXX: Assert mtx is held ... */
 	VRBT_FOREACH_SAFE(x, tbtree, buckets, y) {
 		CHECK_OBJ_NOTNULL(x, TBUCKET_MAGIC);
-		if (now - x->last_used > x->period) {
+		if (now - x->last_used > x->period && (x->block == 0 || now > x->block)) {
 			VRBT_REMOVE(tbtree, buckets, x);
 			FREE_OBJ(x);
 		}


### PR DESCRIPTION
In this PR I have added a check for block parameter in `run_gc` function while removing expired buckets. We should keep blocked buckets until their block duration has ended, even if their expiration period has already ended. 

I have added below condition in code.

```
if (now - x->last_used > x->period && (x->block == 0 || now > x->block)) {
	VRBT_REMOVE(tbtree, buckets, x);
	FREE_OBJ(x);
}
```

1. `x->block == 0` condition check that bucket is not currently blocked.
2. `now > x->block`condition check that if the current time is greater than the end time the bucket was blocked.

This PR fixes the issue #206 