### PR TITLE
vsthrottle test case 6 added to makefile

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -146,6 +146,7 @@ VMOD_TESTS = \
 	tests/vsthrottle/test03.vtc \
 	tests/vsthrottle/test04.vtc \
 	tests/vsthrottle/test05.vtc \
+	tests/vsthrottle/test06.vtc \
 	tests/xkey/test01.vtc \
 	tests/xkey/test02.vtc \
 	tests/xkey/test03.vtc \


### PR DESCRIPTION
Adding test case 6 to the src/Makefile so that it can be run as part of the `make check` command.