### PR TITLE
vmod-saintmode: Allow using blacklist in vcl_backend_error

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -124,6 +124,8 @@ VMOD_TESTS = \
 	tests/saintmode/test03.vtc \
 	tests/saintmode/test04.vtc \
 	tests/saintmode/test05.vtc \
+	tests/saintmode/test06.vtc \
+	tests/saintmode/test07.vtc \
 	tests/str/test01.vtc \
 	tests/str/test02.vtc \
 	tests/str/test03.vtc \

--- a/src/tests/saintmode/test07.vtc
+++ b/src/tests/saintmode/test07.vtc
@@ -1,0 +1,28 @@
+varnishtest "Test saintmode blacklist in vcl_backend_error"
+
+varnish v1 -vcl+backend {
+	import saintmode from "${vmod_builddir}/.libs/libvmod_saintmode.so";
+
+	backend ko {
+		.host = "192.0.2.1";
+		.port = "80";
+	}
+
+	sub vcl_init {
+		new sm = saintmode.saintmode(ko, 1);
+	}
+
+	sub vcl_backend_fetch {
+		set bereq.backend = sm.backend();
+	}
+
+	sub vcl_backend_error {
+		saintmode.blacklist(0.5s);
+	}
+} -start
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+	expect resp.status == 503
+} -run

--- a/src/vmod_saintmode.c
+++ b/src/vmod_saintmode.c
@@ -118,9 +118,9 @@ vmod_denylist(VRT_CTX, struct vmod_priv *priv, VCL_DURATION expires) {
 	}
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	if (ctx->method != VCL_MET_BACKEND_RESPONSE) {
+	if (!ctx->bo || !ctx->bo->director_resp) {
 		VSLb(ctx->vsl, SLT_VCL_Error, "saintmode.denylist() called"
-		    " outside of vcl_backend_response");
+				" outside of vcl_backend_response and vcl_backend_error");
 		return;
 	}
 

--- a/src/vmod_saintmode.vcc
+++ b/src/vmod_saintmode.vcc
@@ -74,9 +74,10 @@ Example::
 $ABI vrt
 $Function VOID denylist(PRIV_VCL, DURATION expires)
 
-Marks the backend as sick for a specific object. Used in vcl_backend_response.
+Marks the backend as sick for a specific object. Used in vcl_backend_response
+and vcl_backend_error.
 Corresponds to the use of ``beresp.saintmode`` in Varnish 3.0. Only available
-in vcl_backend_response.
+in vcl_backend_response and vcl_backend_error.
 
 Example::
 


### PR DESCRIPTION
In a way, this reverts [1].

Previously, we would prevent users from blacklisting a backend from vcl_backend_error. But this is actually useful to users: when a backend fails to respond (and is considered healthy due to e.g. a varnishadm call), we may want to blacklist it for a short while, in order to `return (retry)` and be sure that we do not use this backend for our second try.

This changes the behavior to checking if there is an available backend, e.g. if we are in vcl_backend_response or vcl_backend_error.

[1]: https://github.com/varnish/libvmod-saintmode/commit/d8658c9331c17f4d2979f5b69c94d05866727a5a