### PR TITLE
remove unnecessary asserts

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -159,7 +159,8 @@ VMOD_TESTS = \
 	tests/xkey/test10.vtc \
 	tests/xkey/test11.vtc \
 	tests/xkey/test12.vtc \
-	tests/xkey/test13.vtc
+	tests/xkey/test13.vtc \
+	tests/xkey/test14.vtc
 
 TESTS = $(VMOD_TESTS)
 

--- a/src/tests/xkey/test14.vtc
+++ b/src/tests/xkey/test14.vtc
@@ -1,0 +1,53 @@
+varnishtest "xkey.purge() from backend context"
+
+server s1 {
+	rxreq
+	txresp -hdr "xkey: foo" 
+
+	rxreq
+	txresp -hdr "xkey: bar" -hdr "xkey-purge: foo"
+
+	rxreq
+	txresp -hdr "xkey: foo" 
+} -start
+
+varnish v1 -vcl+backend {
+	import xkey from "${vmod_builddir}/.libs/libvmod_xkey.so";
+
+	sub vcl_backend_response {
+		if (beresp.http.xkey-purge) {
+			set beresp.http.purged = xkey.purge(beresp.http.xkey-purge);
+		}
+	}
+} -start
+
+# get a first object
+client c1 {
+	txreq -url "/foo"
+	rxresp
+} -run
+
+delay 1
+
+varnish v1 -expect n_object == 1
+
+# fetching the second object invalidates the first one
+client c1 {
+	txreq -url "/bar"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.purged == 1
+} -run
+
+delay 1
+
+varnish v1 -expect n_object == 1
+
+client c1 {
+	txreq -url "/foo"
+	rxresp
+} -run
+
+delay 1
+
+varnish v1 -expect n_object == 2

--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -515,8 +515,6 @@ purge(VRT_CTX, VCL_STRING key, VCL_INT do_soft)
 	int i = 0;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
-	CHECK_OBJ_NOTNULL(ctx->req->wrk, WORKER_MAGIC);
 
 	if (!key || !*key)
 		return (0);


### PR DESCRIPTION
We only use `ctx->now`.

Removing the asserts will allow users to call `xkey.purge()` from a backend context, if that's a too big of a footgun, we can use `$Restrict`