### PR TITLE
Adjust var.set test to changed PRIV_TASK allocation

### DIFF
--- a/src/tests/var/test06.vtc
+++ b/src/tests/var/test06.vtc
@@ -12,6 +12,8 @@ varnish v1 -vcl+backend {
         import vtc;
 
 	sub vcl_deliver {
+	       # prime the PRIV_TASK allocation
+	       var.set("x", "42");
                if (req.url == "/a") {
                    # Leave only a single byte in the workspace free.
                    vtc.workspace_alloc(client, -1);


### PR DESCRIPTION
the PRIV_TASK is no longer allocated in the C function preamble, but rather when the function using it is called.

See #222
See Varnish-Cache 7d06b8b98350de557568d712ff089d3c961d0618