### PR TITLE
xkey: drop the superfluous registration mutex

### DIFF
--- a/src/vmod_xkey.c
+++ b/src/vmod_xkey.c
@@ -42,15 +42,6 @@
 #include "VSC_xkey.h"
 
 static pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
-/*
- * reg_mtx serialises the n_init refcount and the Obj{,Un}SubscribeEvents()
- * calls. It must be distinct from mtx: ObjSendEvent() invokes xkey_cb() (which
- * takes mtx) while holding the core oev_rwl, so subscribing/unsubscribing while
- * holding mtx would create an mtx <-> oev_rwl cycle (a real deadlock on the
- * last discard racing a global insert/expire event). With reg_mtx the order is
- * reg_mtx -> oev_rwl -> mtx, a strict hierarchy.
- */
-static pthread_mutex_t reg_mtx = PTHREAD_MUTEX_INITIALIZER;
 static int n_init = 0;
 
 static struct vsc_seg *vsc_seg = NULL;
@@ -577,9 +568,9 @@ vmod_event(VRT_CTX, struct vmod_priv *priv, enum vcl_event_e e)
 	(void)ctx;
 	(void)priv;
 
+	/* vmod_event() runs only on the CLI thread; n_init needs no lock. */
 	switch (e) {
 	case VCL_EVENT_LOAD:
-		AZ(pthread_mutex_lock(&reg_mtx));
 		if (n_init == 0) {
 			xkey_cb_handle = ObjSubscribeEvents(xkey_cb, NULL,
 			    OEV_INSERT|OEV_EXPIRE);
@@ -591,20 +582,14 @@ vmod_event(VRT_CTX, struct vmod_priv *priv, enum vcl_event_e e)
 		}
 		AN(xkey_cb_handle);
 		n_init++;
-		AZ(pthread_mutex_unlock(&reg_mtx));
 		break;
 	case VCL_EVENT_DISCARD:
-		AZ(pthread_mutex_lock(&reg_mtx));
 		assert(n_init > 0);
 		n_init--;
 		AN(xkey_cb_handle);
 		if (n_init == 0) {
-			/*
-			 * Unsubscribe outside mtx: this wrlocks oev_rwl and
-			 * drains in-flight xkey_cb() callbacks, which take mtx.
-			 * After it returns no callback can run, so the cleanup
-			 * below can safely take mtx to free the tree.
-			 */
+			/* Unsubscribe outside mtx: it drains xkey_cb()
+			 * callbacks that take mtx. */
 			ObjUnsubscribeEvents(&xkey_cb_handle);
 			AZ(xkey_cb_handle);
 			AZ(pthread_mutex_lock(&mtx));
@@ -613,7 +598,6 @@ vmod_event(VRT_CTX, struct vmod_priv *priv, enum vcl_event_e e)
 			VSC_xkey_Destroy(&vsc_seg);
 			vsc = NULL;
 		}
-		AZ(pthread_mutex_unlock(&reg_mtx));
 		break;
 	default:
 		break;


### PR DESCRIPTION
vmod_event() is only ever called on the CLI thread, and n_init is touched nowhere else. The refcount therefore races with nothing and needs no lock, and Obj{,Un}SubscribeEvents() already serialise their own state under the core oev_rwl.

The earlier deadlock fix added reg_mtx around the subscribe/unsubscribe calls, but with a single-threaded caller that only ever takes an uncontended lock. Remove it. The one real constraint stays: unsubscribe must run outside mtx, since it drains in-flight xkey_cb() callbacks that take mtx; mtx now guards only the tree cleanup.

Suggested-by: Nils Goroll <nils.goroll@uplex.de>